### PR TITLE
feat: merge phase-1 through phase-7 + 3-phase cost-optimized analyzer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+---
+description: Instructions building apps with MCP
+globs: *
+alwaysApply: true
+---
+
+# InsForge SDK Documentation - Overview
+
+## What is InsForge?
+
+Backend-as-a-service (BaaS) platform providing:
+
+- **Database**: PostgreSQL with PostgREST API
+- **Authentication**: Email/password + OAuth (Google, GitHub)
+- **Storage**: File upload/download
+- **AI**: Chat completions and image generation (OpenAI-compatible)
+- **Functions**: Serverless function deployment
+- **Realtime**: WebSocket pub/sub (database + client events)
+
+## Installation
+
+The following is a step-by-step guide to installing and using the InsForge TypeScript SDK for Web applications. If you are building other types of applications, please refer to:
+- [Swift SDK documentation](/sdks/swift/overview) for iOS, macOS, tvOS, and watchOS applications.
+- [Kotlin SDK documentation](/sdks/kotlin/overview) for Android applications.
+- [REST API documentation](/sdks/rest/overview) for direct HTTP API access.
+
+### 🚨 CRITICAL: Follow these steps in order
+
+### Step 1: Download Template
+
+Use the `download-template` MCP tool to create a new project with your backend URL and anon key pre-configured.
+
+### Step 2: Install SDK
+
+```bash
+npm install @insforge/sdk@latest
+```
+
+### Step 3: Create SDK Client
+
+You must create a client instance using `createClient()` with your base URL and anon key:
+
+```javascript
+import { createClient } from '@insforge/sdk';
+
+const client = createClient({
+  baseUrl: 'https://your-app.region.insforge.app',  // Your InsForge backend URL
+  anonKey: 'your-anon-key-here'       // Get this from backend metadata
+});
+
+```
+
+**API BASE URL**: Your API base URL is `https://your-app.region.insforge.app`.
+
+## Getting Detailed Documentation
+
+### 🚨 CRITICAL: Always Fetch Documentation Before Writing Code
+
+InsForge provides official SDKs and REST APIs, use them to interact with InsForge services from your application code.
+
+- [TypeScript SDK](/sdks/typescript/overview) - JavaScript/TypeScript
+- [Swift SDK](/sdks/swift/overview) - iOS, macOS, tvOS, and watchOS
+- [Kotlin SDK](/sdks/kotlin/overview) - Android and Kotlin Multiplatform
+- [REST API](/sdks/rest/overview) - Direct HTTP API access
+
+Before writing or editing any InsForge integration code, you **MUST** call the `fetch-docs` or `fetch-sdk-docs` MCP tool to get the latest SDK documentation. This ensures you have accurate, up-to-date implementation patterns.
+
+### Use the InsForge `fetch-docs` MCP tool to get specific SDK documentation:
+
+Available documentation types:
+
+- `"instructions"` - Essential backend setup (START HERE)
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"db-sdk-typescript"` - Database operations with TypeScript SDK
+- **Authentication** - Choose based on implementation:
+  - `"auth-sdk-typescript"` - TypeScript SDK methods for custom auth flows
+  - `"auth-components-react"` - Pre-built auth UI for React+Vite (singlepage App)
+  - `"auth-components-react-router"` - Pre-built auth UI for React(Vite+React Router) (Multipage App)
+  - `"auth-components-nextjs"` - Pre-built auth UI for Nextjs (SSR App)
+- `"storage-sdk"` - File storage operations
+- `"functions-sdk"` - Serverless functions invocation
+- `"ai-integration-sdk"` - AI chat and image generation
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"deployment"` - Deploy frontend applications via MCP tool
+
+These documentations are mostly for TypeScript SDK. For other languages, you can also use `fetch-sdk-docs` mcp tool to get specific documentation.
+
+### Use the InsForge `fetch-sdk-docs` MCP tool to get specific SDK documentation
+
+You can fetch sdk documentation using the `fetch-sdk-docs` MCP tool with specific feature type and language.
+
+Available feature types:
+- db - Database operations
+- storage - File storage operations
+- functions - Serverless functions invocation
+- auth - User authentication
+- ai - AI chat and image generation
+- realtime - Real-time pub/sub (database + client events) via WebSockets
+
+Available languages:
+- typescript - JavaScript/TypeScript SDK
+- swift - Swift SDK (for iOS, macOS, tvOS, and watchOS)
+- kotlin - Kotlin SDK (for Android and JVM applications)
+- rest-api - REST API
+
+## When to Use SDK vs MCP Tools
+
+### Always SDK for Application Logic:
+
+- Authentication (register, login, logout, profiles)
+- Database CRUD (select, insert, update, delete)
+- Storage operations (upload, download files)
+- AI operations (chat, image generation)
+- Serverless function invocation
+
+### Use MCP Tools for Infrastructure:
+
+- Project scaffolding (`download-template`) - Download starter templates with InsForge integration
+- Backend setup and metadata (`get-backend-metadata`)
+- Database schema management (`run-raw-sql`, `get-table-schema`)
+- Storage bucket creation (`create-bucket`, `list-buckets`, `delete-bucket`)
+- Serverless function deployment (`create-function`, `update-function`, `delete-function`)
+- Frontend deployment (`create-deployment`) - Deploy frontend apps to InsForge hosting
+
+## Important Notes
+
+- For auth: use `auth-sdk` for custom UI, or framework-specific components for pre-built UI
+- SDK returns `{data, error}` structure for all operations
+- Database inserts require array format: `[{...}]`
+- Serverless functions have single endpoint (no subpaths)
+- Storage: Upload files to buckets, store URLs in database
+- AI operations are OpenAI-compatible
+- **EXTRA IMPORTANT**: Use Tailwind CSS 3.4 (do not upgrade to v4). Lock these dependencies in `package.json`

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -39,3 +39,18 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# InsForge & AI agent skills
+.insforge
+.agent
+.agents
+.augment
+.claude
+.cline
+.github/copilot*
+.kilocode
+.qoder
+.qwen
+.roo
+.trae
+.windsurf

--- a/apps/web/__tests__/lib/auth.test.ts
+++ b/apps/web/__tests__/lib/auth.test.ts
@@ -19,8 +19,9 @@ async function authorize(
     password: credentials.password,
   });
   if (error || !data?.user) return null;
-  const u = data.user;
-  return { id: u.id, email: u.email, name: u.name ?? null, image: u.image ?? null };
+  const u = data.user as { id: string; email: string; name?: string | null; image?: string | null; profile?: { name?: string | null } | null };
+  const name = u.name ?? u.profile?.name ?? null;
+  return { id: u.id, email: u.email, name, image: u.image ?? null };
 }
 
 describe('authorize', () => {

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,16 @@ import { Button } from '@/components/ui/button';
 import { RepoImportDialog } from '@/components/dashboard/repo-import-dialog';
 import { cn } from '@/lib/utils';
 
+type ActivityEvent = {
+  id: string;
+  type: string;
+  message: string;
+  projectId: string | null;
+  projectName: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
 type Project = {
   id: string;
   name: string;
@@ -18,6 +28,27 @@ type Project = {
   createdAt: string;
   updatedAt: string;
 };
+
+const ACTIVITY_ICONS: Record<string, string> = {
+  project_created:      '📁',
+  analysis_started:     '🔍',
+  analysis_completed:   '✅',
+  analysis_failed:      '❌',
+  injection_started:    '⚡',
+  injection_completed:  '🎉',
+  injection_failed:     '❌',
+  pr_opened:            '🔀',
+};
+
+function timeAgoShort(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
 
 const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string }> = {
   draft:     { label: 'Draft',     color: '#8589b2', bg: 'rgba(133,137,178,0.1)' },
@@ -44,13 +75,7 @@ function getColor(id: string) {
 }
 
 function timeAgo(iso: string) {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+  return timeAgoShort(iso);
 }
 
 export default function DashboardPage() {
@@ -59,6 +84,7 @@ export default function DashboardPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [importOpen, setImportOpen] = useState(false);
+  const [activity, setActivity] = useState<ActivityEvent[]>([]);
 
   const fetchProjects = useCallback(async () => {
     setLoading(true);
@@ -68,7 +94,16 @@ export default function DashboardPage() {
     setLoading(false);
   }, []);
 
+  const fetchActivity = useCallback(async () => {
+    const res = await fetch('/api/activity');
+    if (res.ok) {
+      const data = await res.json() as { events: ActivityEvent[] };
+      setActivity(data.events ?? []);
+    }
+  }, []);
+
   useEffect(() => { void fetchProjects(); }, [fetchProjects]);
+  useEffect(() => { void fetchActivity(); }, [fetchActivity]);
 
   const firstName = session?.user?.name?.split(' ')[0] ?? 'there';
   const hour = new Date().getHours();
@@ -213,7 +248,28 @@ export default function DashboardPage() {
         </div>
       )}
 
-      <RepoImportDialog open={importOpen} onOpenChange={setImportOpen} />
+      {/* Activity feed */}
+      {activity.length > 0 && (
+        <div className="mt-8">
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">Recent Activity</h2>
+          <div className="bg-white rounded-xl border border-gray-100 divide-y divide-gray-50">
+            {activity.slice(0, 8).map(event => (
+              <div key={event.id} className="flex items-start gap-3 px-4 py-3">
+                <span className="text-base shrink-0 mt-0.5">{ACTIVITY_ICONS[event.type] ?? '📌'}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-gray-700 truncate">{event.message}</p>
+                  {event.projectName && (
+                    <p className="text-xs text-gray-400 mt-0.5 truncate">{event.projectName}</p>
+                  )}
+                </div>
+                <span className="text-xs text-gray-400 shrink-0 mt-0.5">{timeAgoShort(event.createdAt)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <RepoImportDialog open={importOpen} onOpenChange={setImportOpen} onImported={fetchProjects} />
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -2,32 +2,31 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Label } from '@/components/ui/label';
+import { RepoImportDialog } from '@/components/dashboard/repo-import-dialog';
 import { cn } from '@/lib/utils';
 
 type Project = {
   id: string;
   name: string;
   description: string | null;
+  repoUrl: string | null;
+  repoFullName: string | null;
+  status: string;
+  prUrl: string | null;
   createdAt: string;
   updatedAt: string;
+};
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string }> = {
+  draft:     { label: 'Draft',     color: '#8589b2', bg: 'rgba(133,137,178,0.1)' },
+  pending:   { label: 'Pending',   color: '#f59e0b', bg: 'rgba(245,158,11,0.1)' },
+  analyzing: { label: 'Analyzing', color: '#3b82f6', bg: 'rgba(59,130,246,0.1)' },
+  analyzed:  { label: 'Ready',     color: '#8b5cf6', bg: 'rgba(139,92,246,0.1)' },
+  injecting: { label: 'Injecting', color: '#3b82f6', bg: 'rgba(59,130,246,0.1)' },
+  injected:  { label: 'Injected',  color: '#10b981', bg: 'rgba(16,185,129,0.1)' },
+  error:     { label: 'Error',     color: '#ef4444', bg: 'rgba(239,68,68,0.1)' },
 };
 
 const PROJECT_COLORS = [
@@ -44,34 +43,22 @@ function getColor(id: string) {
   return PROJECT_COLORS[sum % PROJECT_COLORS.length];
 }
 
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 export default function DashboardPage() {
   const { data: session } = useSession();
+  const router = useRouter();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
-
-  // Create dialog
-  const [createOpen, setCreateOpen] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [newDesc, setNewDesc] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState('');
-
-  // Edit dialog
-  const [editProject, setEditProject] = useState<Project | null>(null);
-  const [editName, setEditName] = useState('');
-  const [editDesc, setEditDesc] = useState('');
-  const [saving, setSaving] = useState(false);
-
-  // Delete
-  const [deleting, setDeleting] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   const fetchProjects = useCallback(async () => {
     setLoading(true);
@@ -83,123 +70,43 @@ export default function DashboardPage() {
 
   useEffect(() => { void fetchProjects(); }, [fetchProjects]);
 
-  async function handleCreate() {
-    if (!newName.trim()) { setCreateError('Name is required'); return; }
-    setCreating(true);
-    setCreateError('');
-    const res = await fetch('/api/projects', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newName.trim(), description: newDesc.trim() }),
-    });
-    const data = await res.json() as { project?: Project; error?: string };
-    setCreating(false);
-    if (!res.ok) { setCreateError(data.error ?? 'Failed to create'); return; }
-    setProjects(prev => [data.project!, ...prev]);
-    setCreateOpen(false);
-    setNewName('');
-    setNewDesc('');
-  }
-
-  async function handleEdit() {
-    if (!editProject) return;
-    setSaving(true);
-    const res = await fetch(`/api/projects/${editProject.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: editName.trim(), description: editDesc.trim() }),
-    });
-    const data = await res.json() as { project?: Project };
-    setSaving(false);
-    if (res.ok && data.project) {
-      setProjects(prev => prev.map(p => p.id === editProject.id ? data.project! : p));
-      setEditProject(null);
-    }
-  }
-
-  async function handleDelete(id: string) {
-    if (!confirm('Delete this project? This cannot be undone.')) return;
-    setDeleting(id);
-    await fetch(`/api/projects/${id}`, { method: 'DELETE' });
-    setProjects(prev => prev.filter(p => p.id !== id));
-    setDeleting(null);
-  }
-
   const firstName = session?.user?.name?.split(' ')[0] ?? 'there';
   const hour = new Date().getHours();
   const greeting = hour < 12 ? 'Good morning' : hour < 17 ? 'Good afternoon' : 'Good evening';
 
+  const injected = projects.filter(p => p.status === 'injected').length;
+
   return (
     <div className="max-w-6xl">
-      {/* Page header */}
+      {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">
-            {greeting}, {firstName} 👋
+            {greeting}, {firstName}
           </h1>
           <p className="text-gray-500 text-sm mt-1">
             {projects.length === 0
-              ? 'Create your first project to get started'
-              : `You have ${projects.length} project${projects.length !== 1 ? 's' : ''}`}
+              ? 'Import your first GitHub repo to get started'
+              : `${projects.length} project${projects.length !== 1 ? 's' : ''} · ${injected} injected`}
           </p>
         </div>
-        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-          <DialogTrigger>
-            <Button className="bg-violet-600 hover:bg-violet-700 text-white gap-2" onClick={() => setCreateOpen(true)} type="button">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              New Project
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Create a new project</DialogTitle>
-              <DialogDescription>Give your project a name and optional description.</DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4 py-2">
-              <div>
-                <Label htmlFor="proj-name">Project name *</Label>
-                <Input
-                  id="proj-name"
-                  placeholder="My awesome project"
-                  value={newName}
-                  onChange={e => setNewName(e.target.value)}
-                  onKeyDown={e => e.key === 'Enter' && void handleCreate()}
-                  autoFocus
-                />
-                {createError && <p className="text-xs text-red-500 mt-1">{createError}</p>}
-              </div>
-              <div>
-                <Label htmlFor="proj-desc">Description (optional)</Label>
-                <Input
-                  id="proj-desc"
-                  placeholder="What is this project about?"
-                  value={newDesc}
-                  onChange={e => setNewDesc(e.target.value)}
-                />
-              </div>
-            </div>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
-              <Button
-                onClick={() => void handleCreate()}
-                disabled={creating}
-                className="bg-violet-600 hover:bg-violet-700"
-              >
-                {creating ? 'Creating...' : 'Create project'}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <Button
+          onClick={() => setImportOpen(true)}
+          className="bg-violet-600 hover:bg-violet-700 text-white gap-2"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Import repo
+        </Button>
       </div>
 
-      {/* Stats row */}
+      {/* Stats */}
       <div className="grid grid-cols-3 gap-4 mb-8">
         {[
           { label: 'Total Projects', value: projects.length, icon: '📁', color: 'bg-violet-50 text-violet-700' },
-          { label: 'Active This Month', value: projects.filter(p => new Date(p.updatedAt) > new Date(Date.now() - 30 * 86400_000)).length, icon: '⚡', color: 'bg-blue-50 text-blue-700' },
-          { label: 'Member Since', value: session?.user ? new Date().getFullYear() : '—', icon: '🗓️', color: 'bg-emerald-50 text-emerald-700' },
+          { label: 'Injections Done', value: injected, icon: '⚡', color: 'bg-emerald-50 text-emerald-700' },
+          { label: 'In Progress', value: projects.filter(p => ['analyzing','injecting','analyzed'].includes(p.status)).length, icon: '🔄', color: 'bg-blue-50 text-blue-700' },
         ].map(stat => (
           <div key={stat.label} className="bg-white rounded-xl border border-gray-100 p-5 flex items-center gap-4">
             <div className={cn('w-10 h-10 rounded-lg flex items-center justify-center text-lg', stat.color)}>
@@ -226,117 +133,87 @@ export default function DashboardPage() {
         </div>
       ) : projects.length === 0 ? (
         <div className="border-2 border-dashed border-gray-200 rounded-2xl p-16 text-center">
-          <div className="w-16 h-16 bg-violet-50 rounded-2xl flex items-center justify-center mx-auto mb-4 text-3xl">
-            📁
+          <div className="w-16 h-16 bg-violet-50 rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-violet-500" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
           </div>
           <h3 className="text-gray-900 font-semibold mb-1">No projects yet</h3>
-          <p className="text-gray-500 text-sm mb-6">Create your first project to start organizing your work.</p>
+          <p className="text-gray-500 text-sm mb-6">Import a GitHub repo and Prodify will analyze it and inject production-ready auth, payments, and database infrastructure.</p>
           <Button
-            onClick={() => setCreateOpen(true)}
+            onClick={() => setImportOpen(true)}
             className="bg-violet-600 hover:bg-violet-700 text-white"
           >
-            Create your first project
+            Import your first repo
           </Button>
         </div>
       ) : (
         <div className="grid grid-cols-3 gap-4">
-          {projects.map(project => (
-            <div
-              key={project.id}
-              className="bg-white rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all group p-5"
-            >
-              {/* Card header */}
-              <div className="flex items-start justify-between mb-4">
-                <div className={cn('w-10 h-10 rounded-lg bg-gradient-to-br flex items-center justify-center text-white font-semibold text-sm shrink-0', getColor(project.id))}>
-                  {project.name[0]?.toUpperCase()}
+          {projects.map(project => {
+            const statusCfg = STATUS_CONFIG[project.status] ?? STATUS_CONFIG.draft;
+            return (
+              <div
+                key={project.id}
+                onClick={() => router.push(`/dashboard/projects/${project.id}`)}
+                className="bg-white rounded-xl border border-gray-100 hover:border-violet-200 hover:shadow-sm transition-all cursor-pointer p-5 group"
+              >
+                <div className="flex items-start justify-between mb-4">
+                  <div className={cn('w-10 h-10 rounded-lg bg-gradient-to-br flex items-center justify-center text-white font-semibold text-sm shrink-0', getColor(project.id))}>
+                    {project.name[0]?.toUpperCase()}
+                  </div>
+                  <span
+                    className="text-xs font-medium px-2 py-0.5 rounded-full"
+                    style={{ color: statusCfg.color, background: statusCfg.bg }}
+                  >
+                    {statusCfg.label}
+                  </span>
                 </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger className="opacity-0 group-hover:opacity-100 w-7 h-7 flex items-center justify-center rounded-md hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-all">
-                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-                    </svg>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => {
-                      setEditProject(project);
-                      setEditName(project.name);
-                      setEditDesc(project.description ?? '');
-                    }}>
-                      Edit
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="text-red-600 focus:text-red-600"
-                      onClick={() => void handleDelete(project.id)}
-                      disabled={deleting === project.id}
+
+                <h3 className="font-semibold text-gray-900 text-sm mb-0.5 truncate">{project.name}</h3>
+                {project.repoFullName ? (
+                  <p className="text-xs text-gray-400 truncate mb-3">{project.repoFullName}</p>
+                ) : (
+                  <p className="text-xs text-gray-400 mb-3">{project.description ?? 'No description'}</p>
+                )}
+
+                <div className="flex items-center justify-between pt-3 border-t border-gray-50">
+                  <span className="text-xs text-gray-400">{timeAgo(project.updatedAt ?? project.createdAt)}</span>
+                  {project.prUrl ? (
+                    <a
+                      href={project.prUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={e => e.stopPropagation()}
+                      className="text-xs text-violet-600 hover:underline font-medium"
                     >
-                      {deleting === project.id ? 'Deleting...' : 'Delete'}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      View PR →
+                    </a>
+                  ) : project.status === 'pending' ? (
+                    <span className="text-xs text-amber-600 font-medium">Needs analysis</span>
+                  ) : project.status === 'analyzed' ? (
+                    <span className="text-xs text-violet-600 font-medium">Ready to inject</span>
+                  ) : null}
+                </div>
               </div>
-
-              {/* Name & description */}
-              <h3 className="font-semibold text-gray-900 text-sm mb-1 truncate">{project.name}</h3>
-              <p className="text-xs text-gray-500 line-clamp-2 min-h-[2.5rem]">
-                {project.description ?? 'No description'}
-              </p>
-
-              {/* Footer */}
-              <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-50">
-                <span className="text-xs text-gray-400">{formatDate(project.createdAt)}</span>
-                <span className="text-xs bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full font-medium">Active</span>
-              </div>
-            </div>
-          ))}
+            );
+          })}
 
           {/* Add new card */}
           <button
-            onClick={() => setCreateOpen(true)}
-            className="bg-gray-50 hover:bg-gray-100 rounded-xl border-2 border-dashed border-gray-200 hover:border-gray-300 p-5 text-center flex flex-col items-center justify-center gap-2 transition-all min-h-[180px] group"
+            onClick={() => setImportOpen(true)}
+            className="bg-gray-50 hover:bg-gray-100 rounded-xl border-2 border-dashed border-gray-200 hover:border-violet-300 p-5 text-center flex flex-col items-center justify-center gap-2 transition-all min-h-[180px] group"
           >
             <div className="w-10 h-10 rounded-lg bg-white border border-gray-200 flex items-center justify-center group-hover:border-violet-300 group-hover:text-violet-600 text-gray-400 transition-all">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
               </svg>
             </div>
-            <span className="text-sm text-gray-500 font-medium">New Project</span>
+            <span className="text-sm text-gray-500 font-medium">Import repo</span>
           </button>
         </div>
       )}
 
-      {/* Edit dialog */}
-      <Dialog open={!!editProject} onOpenChange={open => !open && setEditProject(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit project</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            <div>
-              <Label htmlFor="edit-name">Name</Label>
-              <Input
-                id="edit-name"
-                value={editName}
-                onChange={e => setEditName(e.target.value)}
-                autoFocus
-              />
-            </div>
-            <div>
-              <Label htmlFor="edit-desc">Description</Label>
-              <Input
-                id="edit-desc"
-                value={editDesc}
-                onChange={e => setEditDesc(e.target.value)}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditProject(null)}>Cancel</Button>
-            <Button onClick={() => void handleEdit()} disabled={saving} className="bg-violet-600 hover:bg-violet-700">
-              {saving ? 'Saving...' : 'Save changes'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <RepoImportDialog open={importOpen} onOpenChange={setImportOpen} />
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -85,6 +85,9 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
   const [injectProgress, setInjectProgress] = useState<ProgressEvent[]>([]);
   const [injectError, setInjectError] = useState('');
 
+  // Delete state
+  const [deleting, setDeleting] = useState(false);
+
   const fetchProject = useCallback(async () => {
     const res = await fetch(`/api/projects/${id}`);
     if (!res.ok) { router.push('/dashboard'); return; }
@@ -178,6 +181,13 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
     setInjecting(false);
   }
 
+  async function deleteProject() {
+    if (!confirm('Delete this project? This cannot be undone.')) return;
+    setDeleting(true);
+    await fetch(`/api/projects/${id}`, { method: 'DELETE' });
+    router.push('/dashboard');
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -218,7 +228,19 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
             </a>
           )}
         </div>
-        <StatusBadge status={status} />
+        <div className="flex items-center gap-2">
+          <StatusBadge status={status} />
+          <button
+            onClick={() => void deleteProject()}
+            disabled={deleting}
+            className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+            title="Delete project"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {/* PENDING — needs analysis */}

--- a/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -1,119 +1,562 @@
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { insforge } from '@/lib/insforge';
+'use client';
 
-const MODULE_INFO: Record<string, { label: string; icon: string; desc: string; color: string; border: string }> = {
-  auth: {
-    label: 'Authentication',
-    icon: '🔐',
-    desc: 'Email + password sign-up/login, GitHub OAuth, JWT sessions, forgot/reset password flow, middleware route protection.',
-    color: 'rgba(87,94,254,0.08)',
-    border: 'rgba(87,94,254,0.3)',
-  },
-  database: {
-    label: 'Database',
-    icon: '🗄️',
-    desc: 'Prisma ORM with PostgreSQL. Schema auto-generated for your models. Neon serverless DB compatible. Migration scripts included.',
-    color: 'rgba(0,215,255,0.08)',
-    border: 'rgba(0,215,255,0.3)',
-  },
-  payments: {
-    label: 'Payments',
-    icon: '💳',
-    desc: 'Stripe Checkout sessions, webhook handler with idempotency, customer portal, subscription status synced to DB.',
-    color: 'rgba(0,215,255,0.05)',
-    border: 'rgba(87,94,254,0.2)',
-  },
+import { useState, useEffect, useCallback, use } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+type AnalysisReport = {
+  detectedStack: {
+    framework: string;
+    language: string;
+    hasAuth: boolean;
+    authProvider: string | null;
+    hasPayments: boolean;
+    paymentsProvider: string | null;
+    hasDatabase: boolean;
+    dbProvider: string | null;
+    hasCI: boolean;
+  };
+  pattern: string;
+  injectionOpportunities: Array<{
+    layer: string;
+    canInject: boolean;
+    currentState: string;
+    proposed: string;
+    filesToCreate: string[];
+    effort: string;
+  }>;
+  conflicts: Array<{
+    description: string;
+    severity: 'warning' | 'blocker';
+    resolution: string;
+  }>;
+  summary: string;
 };
 
-export default async function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
-  const { id } = await params;
-  const { data: project, error } = await insforge.database
-    .from('projects')
-    .select('*')
-    .eq('id', id)
-    .eq('userId', session!.user!.id!)
-    .single();
-  if (error || !project) notFound();
+type Project = {
+  id: string;
+  name: string;
+  repoUrl: string | null;
+  repoFullName: string | null;
+  cloneUrl: string | null;
+  defaultBranch: string | null;
+  status: string;
+  analysisResult: AnalysisReport | null;
+  injectionConfig: { pricingModel: string; userType: string; openPR: boolean } | null;
+  prUrl: string | null;
+  branchName: string | null;
+  createdAt: string;
+};
 
-  const created = new Date(project.createdAt).toLocaleDateString('en-US', {
-    weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
-  });
+type ProgressEvent = { step: number; total: number; message: string };
+
+const LAYER_ICONS: Record<string, string> = {
+  auth: '🔐',
+  payments: '💳',
+  database: '🗄️',
+  ci: '⚙️',
+  env: '🔑',
+};
+
+const EFFORT_COLOR: Record<string, string> = {
+  low: 'text-emerald-600 bg-emerald-50',
+  medium: 'text-amber-600 bg-amber-50',
+  high: 'text-red-600 bg-red-50',
+};
+
+export default function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [project, setProject] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Analysis state
+  const [analysisProgress, setAnalysisProgress] = useState<ProgressEvent[]>([]);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  // Injection config
+  const [pricingModel, setPricingModel] = useState<'per-seat' | 'flat' | 'usage'>('flat');
+  const [userType, setUserType] = useState<'individuals' | 'teams' | 'enterprise'>('individuals');
+  const [openPR, setOpenPR] = useState(true);
+
+  // Injection state
+  const [injecting, setInjecting] = useState(false);
+  const [injectProgress, setInjectProgress] = useState<ProgressEvent[]>([]);
+  const [injectError, setInjectError] = useState('');
+
+  const fetchProject = useCallback(async () => {
+    const res = await fetch(`/api/projects/${id}`);
+    if (!res.ok) { router.push('/dashboard'); return; }
+    const data = await res.json() as { project: Project };
+    setProject(data.project);
+    setLoading(false);
+  }, [id, router]);
+
+  useEffect(() => { void fetchProject(); }, [fetchProject]);
+
+  async function startAnalysis() {
+    if (!project) return;
+    setAnalyzing(true);
+    setAnalysisProgress([]);
+
+    const res = await fetch(`/api/projects/${id}/analyze`, { method: 'POST' });
+    if (!res.ok || !res.body) {
+      setAnalyzing(false);
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      let eventType = '';
+      for (const line of lines) {
+        if (line.startsWith('event: ')) { eventType = line.slice(7).trim(); }
+        if (line.startsWith('data: ')) {
+          try {
+            const payload = JSON.parse(line.slice(6));
+            if (eventType === 'progress') setAnalysisProgress(p => [...p, payload as ProgressEvent]);
+            if (eventType === 'done') await fetchProject();
+            if (eventType === 'error') console.error('[analysis error]', payload);
+          } catch { /* ignore malformed */ }
+        }
+      }
+    }
+    setAnalyzing(false);
+  }
+
+  async function startInjection() {
+    setInjecting(true);
+    setInjectProgress([]);
+    setInjectError('');
+
+    const res = await fetch(`/api/projects/${id}/inject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pricingModel, userType, openPR }),
+    });
+
+    if (!res.ok || !res.body) {
+      const err = await res.json().catch(() => ({ error: 'Injection failed' })) as { error?: string };
+      setInjectError(err.error ?? 'Injection failed');
+      setInjecting(false);
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      let eventType = '';
+      for (const line of lines) {
+        if (line.startsWith('event: ')) { eventType = line.slice(7).trim(); }
+        if (line.startsWith('data: ')) {
+          try {
+            const payload = JSON.parse(line.slice(6));
+            if (eventType === 'progress') setInjectProgress(p => [...p, payload as ProgressEvent]);
+            if (eventType === 'done') await fetchProject();
+            if (eventType === 'error') setInjectError((payload as { message?: string }).message ?? 'Injection failed');
+          } catch { /* ignore */ }
+        }
+      }
+    }
+    setInjecting(false);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="w-6 h-6 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!project) return null;
+
+  const report = project.analysisResult;
+  const status = project.status;
 
   return (
-    <div className="max-w-2xl">
+    <div className="max-w-4xl">
+      {/* Breadcrumb */}
       <div className="mb-6">
-        <Link href="/dashboard" className="text-sm transition-colors" style={{ color: '#8589b2' }}
-          onMouseEnter={undefined}>
+        <Link href="/dashboard" className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
           ← All projects
         </Link>
       </div>
 
-      <div className="flex items-center gap-3 mb-1">
-        <h1 className="text-2xl font-black tracking-tight" style={{ fontFamily: 'var(--font-unbounded)', color: '#e3f4f8' }}>
-          {project.name}
-        </h1>
-        <span
-          className="text-xs font-semibold px-2.5 py-0.5 rounded-full"
-          style={project.status === 'active'
-            ? { background: 'rgba(0,215,255,0.1)', color: '#00d7ff' }
-            : { background: 'rgba(133,137,178,0.15)', color: '#8589b2' }
-          }
-        >
-          {project.status === 'active' ? 'Active' : 'Draft'}
-        </span>
-      </div>
-      {project.description && (
-        <p className="text-sm mb-1" style={{ color: '#8589b2' }}>{project.description}</p>
-      )}
-      <p className="text-xs mb-8" style={{ color: '#8589b2' }}>Created {created}</p>
-
-      <h2 className="text-xs font-semibold uppercase tracking-widest mb-4" style={{ color: '#8589b2' }}>
-        Injected modules
-      </h2>
-      <div className="space-y-3 mb-8">
-        {project.modules.map(mod => {
-          const info = MODULE_INFO[mod] ?? { label: mod, icon: '📦', desc: '', color: 'rgba(87,94,254,0.08)', border: '#323779' };
-          return (
-            <div key={mod} className="rounded-2xl p-4" style={{ background: info.color, border: `1px solid ${info.border}` }}>
-              <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-lg">{info.icon}</span>
-                <span className="font-semibold text-sm" style={{ color: '#e3f4f8' }}>{info.label}</span>
-                <span className="ml-auto text-xs font-medium" style={{ color: '#00d7ff' }}>✓ Injected</span>
-              </div>
-              <p className="text-xs leading-relaxed" style={{ color: '#8589b2' }}>{info.desc}</p>
-            </div>
-          );
-        })}
+      {/* Header */}
+      <div className="flex items-start justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">{project.name}</h1>
+          {project.repoFullName && (
+            <a
+              href={project.repoUrl ?? '#'}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-violet-600 hover:underline flex items-center gap-1"
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              {project.repoFullName}
+            </a>
+          )}
+        </div>
+        <StatusBadge status={status} />
       </div>
 
-      {project.repoUrl && (
-        <div className="rounded-2xl p-4 mb-8" style={{ background: '#25284c', border: '1px solid #323779' }}>
-          <div className="text-sm font-medium mb-1" style={{ color: '#e3f4f8' }}>GitHub repository</div>
-          <a href={project.repoUrl} target="_blank" rel="noopener noreferrer"
-            className="text-sm break-all" style={{ color: '#575efe' }}>
-            {project.repoUrl}
-          </a>
+      {/* PENDING — needs analysis */}
+      {(status === 'pending' || status === 'draft') && !analyzing && (
+        <div className="bg-white rounded-2xl border border-gray-100 p-8 text-center">
+          <div className="w-14 h-14 bg-violet-50 rounded-2xl flex items-center justify-center mx-auto mb-4 text-2xl">🔍</div>
+          <h2 className="font-semibold text-gray-900 mb-2">Ready to analyze</h2>
+          <p className="text-sm text-gray-500 mb-6 max-w-md mx-auto">
+            Prodify will clone your repo and use AWS Bedrock (Claude) to detect your stack, find missing infrastructure, and plan exactly what to inject.
+          </p>
+          <Button
+            onClick={() => void startAnalysis()}
+            className="bg-violet-600 hover:bg-violet-700 text-white"
+          >
+            Analyze repository
+          </Button>
         </div>
       )}
 
-      <div className="rounded-2xl p-5" style={{ background: '#25284c', border: '1px solid #323779' }}>
-        <div className="text-sm font-semibold mb-3" style={{ color: '#e3f4f8' }}>Next steps</div>
-        <ol className="space-y-3">
-          {[
-            <>Run <code className="px-1.5 py-0.5 rounded text-xs font-mono" style={{ background: '#1b1e3d', color: '#00d7ff', border: '1px solid #323779' }}>npx prodify inject</code> in your project directory</>,
-            <>Add your environment variables to <code className="px-1.5 py-0.5 rounded text-xs font-mono" style={{ background: '#1b1e3d', color: '#00d7ff', border: '1px solid #323779' }}>.env.local</code></>,
-            <>Push to GitHub — Prodify creates a branch and opens a PR automatically</>,
-          ].map((step, i) => (
-            <li key={i} className="flex gap-3 text-sm" style={{ color: '#8589b2' }}>
-              <span className="font-mono font-bold shrink-0" style={{ color: '#575efe' }}>{i + 1}.</span>
-              <span>{step}</span>
-            </li>
-          ))}
-        </ol>
+      {/* ANALYZING — progress stream */}
+      {(status === 'analyzing' || analyzing) && (
+        <div className="bg-white rounded-2xl border border-gray-100 p-8">
+          <h2 className="font-semibold text-gray-900 mb-6 flex items-center gap-2">
+            <div className="w-4 h-4 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+            Analyzing repository...
+          </h2>
+          <div className="space-y-3">
+            {[
+              { n: 1, label: 'Cloning repository' },
+              { n: 2, label: 'Reading project files' },
+              { n: 3, label: 'Analyzing with AI (AWS Bedrock)' },
+              { n: 4, label: 'Saving results' },
+            ].map(({ n, label }) => {
+              const done = analysisProgress.some(p => p.step >= n);
+              const active = analysisProgress.some(p => p.step === n);
+              return (
+                <div key={n} className="flex items-center gap-3">
+                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 ${
+                    done ? 'bg-emerald-100 text-emerald-700' : active ? 'bg-violet-100 text-violet-700' : 'bg-gray-100 text-gray-400'
+                  }`}>
+                    {done ? '✓' : n}
+                  </div>
+                  <span className={`text-sm ${done ? 'text-gray-700' : active ? 'text-violet-700 font-medium' : 'text-gray-400'}`}>{label}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* ANALYZED — report + config form */}
+      {status === 'analyzed' && report && !injecting && (
+        <div className="space-y-6">
+          {/* Summary */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-6">
+            <h2 className="font-semibold text-gray-900 mb-3">Analysis complete</h2>
+            <p className="text-sm text-gray-600 mb-4">{report.summary}</p>
+            <div className="flex flex-wrap gap-2">
+              <StackBadge label={report.detectedStack.framework} />
+              <StackBadge label={report.detectedStack.language.toUpperCase()} />
+              {report.detectedStack.authProvider && <StackBadge label={`Auth: ${report.detectedStack.authProvider}`} color="amber" />}
+              {report.detectedStack.dbProvider && <StackBadge label={`DB: ${report.detectedStack.dbProvider}`} color="amber" />}
+              {report.detectedStack.paymentsProvider && <StackBadge label={`Payments: ${report.detectedStack.paymentsProvider}`} color="amber" />}
+              {!report.detectedStack.hasAuth && <StackBadge label="No auth" color="red" />}
+              {!report.detectedStack.hasPayments && <StackBadge label="No payments" color="red" />}
+              {!report.detectedStack.hasDatabase && <StackBadge label="No database" color="red" />}
+            </div>
+          </div>
+
+          {/* Conflicts / warnings */}
+          {report.conflicts.length > 0 && (
+            <div className="space-y-2">
+              {report.conflicts.map((c, i) => (
+                <div
+                  key={i}
+                  className={`rounded-xl p-4 flex gap-3 ${c.severity === 'blocker' ? 'bg-red-50 border border-red-200' : 'bg-amber-50 border border-amber-200'}`}
+                >
+                  <span className="text-lg shrink-0">{c.severity === 'blocker' ? '🚫' : '⚠️'}</span>
+                  <div>
+                    <p className={`text-sm font-medium ${c.severity === 'blocker' ? 'text-red-800' : 'text-amber-800'}`}>{c.description}</p>
+                    <p className={`text-xs mt-0.5 ${c.severity === 'blocker' ? 'text-red-600' : 'text-amber-600'}`}>Resolution: {c.resolution}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Injection opportunities */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-6">
+            <h3 className="font-semibold text-gray-900 mb-4">What will be injected</h3>
+            <div className="space-y-3">
+              {report.injectionOpportunities.map((opp, i) => (
+                <div key={i} className={`rounded-xl p-4 border ${opp.canInject ? 'border-gray-100' : 'border-gray-100 opacity-60'}`}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-lg">{LAYER_ICONS[opp.layer] ?? '📦'}</span>
+                    <span className="font-medium text-sm text-gray-900 capitalize">{opp.layer}</span>
+                    <span className={`ml-auto text-xs font-medium px-2 py-0.5 rounded-full ${EFFORT_COLOR[opp.effort] ?? 'text-gray-600 bg-gray-100'}`}>
+                      {opp.effort} effort
+                    </span>
+                    {opp.canInject
+                      ? <span className="text-xs text-emerald-600 font-medium">✓ Will inject</span>
+                      : <span className="text-xs text-gray-400">Already present</span>
+                    }
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-1">
+                    <span className="line-through">{opp.currentState}</span>
+                    <span>→</span>
+                    <span className="text-gray-700">{opp.proposed}</span>
+                  </div>
+                  {opp.filesToCreate.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {opp.filesToCreate.map(f => (
+                        <code key={f} className="text-xs bg-gray-50 border border-gray-200 text-gray-600 px-1.5 py-0.5 rounded">{f}</code>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Config form */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-6">
+            <h3 className="font-semibold text-gray-900 mb-4">Configure injection</h3>
+            <div className="space-y-5">
+              <OptionGroup
+                label="Pricing model"
+                options={[
+                  { value: 'flat', label: 'Flat rate', desc: 'Single subscription price' },
+                  { value: 'per-seat', label: 'Per seat', desc: 'Charge per user/seat' },
+                  { value: 'usage', label: 'Usage-based', desc: 'Metered billing' },
+                ]}
+                value={pricingModel}
+                onChange={v => setPricingModel(v as typeof pricingModel)}
+              />
+              <OptionGroup
+                label="User type"
+                options={[
+                  { value: 'individuals', label: 'Individuals', desc: 'Single-user accounts' },
+                  { value: 'teams', label: 'Teams', desc: 'Orgs + memberships' },
+                  { value: 'enterprise', label: 'Enterprise', desc: 'Teams + SAML SSO' },
+                ]}
+                value={userType}
+                onChange={v => setUserType(v as typeof userType)}
+              />
+              <div>
+                <p className="text-sm font-medium text-gray-700 mb-2">After injection</p>
+                <div className="flex gap-3">
+                  {[
+                    { v: true, label: 'Open a PR to main', desc: 'Recommended — review before merge' },
+                    { v: false, label: 'Push branch only', desc: 'You\'ll open the PR manually' },
+                  ].map(opt => (
+                    <button
+                      key={String(opt.v)}
+                      onClick={() => setOpenPR(opt.v)}
+                      className={`flex-1 rounded-xl border p-3 text-left transition-all ${
+                        openPR === opt.v
+                          ? 'border-violet-500 bg-violet-50'
+                          : 'border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <p className="text-sm font-medium text-gray-900">{opt.label}</p>
+                      <p className="text-xs text-gray-500 mt-0.5">{opt.desc}</p>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-6 pt-4 border-t border-gray-100 flex items-center justify-between">
+              <p className="text-xs text-gray-400">
+                Branch: <code className="font-mono">prodify/inject-{'<timestamp>'}</code>
+              </p>
+              <Button
+                onClick={() => void startInjection()}
+                className="bg-violet-600 hover:bg-violet-700 text-white"
+                disabled={report.conflicts.some(c => c.severity === 'blocker')}
+              >
+                Inject now
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* INJECTING — progress stream */}
+      {injecting && (
+        <div className="bg-white rounded-2xl border border-gray-100 p-8">
+          <h2 className="font-semibold text-gray-900 mb-6 flex items-center gap-2">
+            <div className="w-4 h-4 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+            Injecting infrastructure...
+          </h2>
+          <div className="space-y-3">
+            {injectProgress.map((p, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <div className="w-6 h-6 rounded-full bg-emerald-100 text-emerald-700 flex items-center justify-center text-xs font-bold shrink-0">✓</div>
+                <span className="text-sm text-gray-700">{p.message}</span>
+              </div>
+            ))}
+            {injectProgress.length > 0 && (
+              <div className="flex items-center gap-3">
+                <div className="w-6 h-6 rounded-full bg-violet-100 flex items-center justify-center shrink-0">
+                  <div className="w-3 h-3 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+                </div>
+                <span className="text-sm text-violet-700 font-medium">Working...</span>
+              </div>
+            )}
+          </div>
+          {injectError && <p className="text-sm text-red-600 mt-4">{injectError}</p>}
+        </div>
+      )}
+
+      {/* INJECTED — success */}
+      {status === 'injected' && !injecting && (
+        <div className="space-y-6">
+          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6">
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-2xl">🎉</span>
+              <h2 className="font-semibold text-emerald-900">Infrastructure injected successfully</h2>
+            </div>
+            <p className="text-sm text-emerald-700 mb-4">
+              Auth, payments, and database infrastructure have been injected and pushed to GitHub.
+            </p>
+            {project.prUrl && (
+              <a
+                href={project.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 bg-white border border-emerald-300 text-emerald-800 text-sm font-medium px-4 py-2 rounded-lg hover:bg-emerald-50 transition-colors"
+              >
+                View PR on GitHub →
+              </a>
+            )}
+            {project.branchName && (
+              <p className="text-xs text-emerald-600 mt-2">
+                Branch: <code className="font-mono">{project.branchName}</code>
+              </p>
+            )}
+          </div>
+
+          <div className="bg-white rounded-2xl border border-gray-100 p-6">
+            <h3 className="font-semibold text-gray-900 mb-4">Next steps</h3>
+            <ol className="space-y-3">
+              {[
+                { done: false, text: 'Review the PR — check every file before merging' },
+                { done: false, text: 'Add env vars from README-prodify.md to your .env.local' },
+                { done: false, text: 'Run the InsForge SQL schema from prodify-layer/db/schema.sql' },
+                { done: false, text: 'Merge the PR to main' },
+                { done: false, text: 'Set up Stripe webhook: stripe listen --forward-to localhost:3000/api/webhooks/stripe' },
+              ].map((step, i) => (
+                <li key={i} className="flex items-start gap-3 text-sm text-gray-600">
+                  <span className="w-5 h-5 rounded border border-gray-300 shrink-0 mt-0.5" />
+                  {step.text}
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              onClick={() => void startAnalysis()}
+            >
+              Re-analyze
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ERROR */}
+      {status === 'error' && !analyzing && (
+        <div className="bg-red-50 border border-red-200 rounded-2xl p-6">
+          <h2 className="font-semibold text-red-900 mb-2">Something went wrong</h2>
+          <p className="text-sm text-red-600 mb-4">The analysis or injection failed. Check your GitHub connection and try again.</p>
+          <Button onClick={() => void startAnalysis()} className="bg-red-600 hover:bg-red-700 text-white">
+            Try again
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; classes: string }> = {
+    draft:     { label: 'Draft',     classes: 'bg-gray-100 text-gray-500' },
+    pending:   { label: 'Pending',   classes: 'bg-amber-100 text-amber-700' },
+    analyzing: { label: 'Analyzing', classes: 'bg-blue-100 text-blue-700' },
+    analyzed:  { label: 'Ready',     classes: 'bg-violet-100 text-violet-700' },
+    injecting: { label: 'Injecting', classes: 'bg-blue-100 text-blue-700' },
+    injected:  { label: 'Injected',  classes: 'bg-emerald-100 text-emerald-700' },
+    error:     { label: 'Error',     classes: 'bg-red-100 text-red-700' },
+  };
+  const cfg = map[status] ?? map.draft;
+  return (
+    <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${cfg.classes}`}>
+      {cfg.label}
+    </span>
+  );
+}
+
+function StackBadge({ label, color = 'gray' }: { label: string; color?: 'gray' | 'amber' | 'red' }) {
+  const classes = {
+    gray: 'bg-gray-100 text-gray-600',
+    amber: 'bg-amber-100 text-amber-700',
+    red: 'bg-red-100 text-red-600',
+  };
+  return (
+    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${classes[color]}`}>{label}</span>
+  );
+}
+
+function OptionGroup({
+  label, options, value, onChange,
+}: {
+  label: string;
+  options: Array<{ value: string; label: string; desc: string }>;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-700 mb-2">{label}</p>
+      <div className="flex gap-3">
+        {options.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            className={`flex-1 rounded-xl border p-3 text-left transition-all ${
+              value === opt.value
+                ? 'border-violet-500 bg-violet-50'
+                : 'border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <p className="text-sm font-medium text-gray-900">{opt.label}</p>
+            <p className="text-xs text-gray-500 mt-0.5">{opt.desc}</p>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -5,6 +5,13 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
+type CodeInsight = {
+  category: 'auth' | 'payments' | 'database' | 'architecture' | 'security' | 'performance';
+  finding: string;
+  evidence: string;
+  recommendation: string;
+};
+
 type AnalysisReport = {
   detectedStack: {
     framework: string;
@@ -26,6 +33,8 @@ type AnalysisReport = {
   };
   pattern: string;
   appDescription?: string;
+  apiRoutes?: string[];
+  codeInsights?: CodeInsight[];
   injectionOpportunities: Array<{
     layer: string;
     canInject: boolean;
@@ -336,7 +345,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
             </div>
 
             {/* Stack badges */}
-            <div className="flex flex-wrap gap-2 mb-4">
+            <div className="flex flex-wrap gap-2 mb-3">
               <StackBadge label={`${report.detectedStack.framework}${report.detectedStack.frameworkVersion ? ` ${report.detectedStack.frameworkVersion}` : ''}`} />
               <StackBadge label={report.detectedStack.language.toUpperCase()} />
               {report.detectedStack.authProvider && <StackBadge label={`Auth: ${report.detectedStack.authProvider}`} color="amber" />}
@@ -349,6 +358,21 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
                 <StackBadge key={dep} label={dep} color="gray" />
               ))}
             </div>
+
+            {/* Stack detail lines */}
+            {(report.detectedStack.authDetails || report.detectedStack.paymentsDetails || report.detectedStack.dbDetails) && (
+              <div className="space-y-1 mb-3">
+                {report.detectedStack.authDetails && (
+                  <p className="text-xs text-gray-500 flex gap-1.5"><span className="text-blue-400 shrink-0">🔐</span>{report.detectedStack.authDetails}</p>
+                )}
+                {report.detectedStack.paymentsDetails && (
+                  <p className="text-xs text-gray-500 flex gap-1.5"><span className="text-emerald-400 shrink-0">💳</span>{report.detectedStack.paymentsDetails}</p>
+                )}
+                {report.detectedStack.dbDetails && (
+                  <p className="text-xs text-gray-500 flex gap-1.5"><span className="text-violet-400 shrink-0">🗄️</span>{report.detectedStack.dbDetails}</p>
+                )}
+              </div>
+            )}
 
             {/* Monetization blockers + quick wins */}
             {report.monetizationReadiness && (
@@ -399,6 +423,59 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
                   </div>
                 </div>
               ))}
+            </div>
+          )}
+
+          {/* Code Insights — real findings from scanning the code */}
+          {report.codeInsights && report.codeInsights.length > 0 && (
+            <div className="bg-white rounded-2xl border border-gray-100 p-6">
+              <h3 className="font-semibold text-gray-900 mb-4">Code findings</h3>
+              <div className="space-y-3">
+                {report.codeInsights.map((insight, i) => {
+                  const categoryColor: Record<string, string> = {
+                    auth: 'bg-blue-50 border-blue-200 text-blue-700',
+                    payments: 'bg-emerald-50 border-emerald-200 text-emerald-700',
+                    database: 'bg-violet-50 border-violet-200 text-violet-700',
+                    security: 'bg-red-50 border-red-200 text-red-700',
+                    performance: 'bg-amber-50 border-amber-200 text-amber-700',
+                    architecture: 'bg-gray-50 border-gray-200 text-gray-700',
+                  };
+                  const categoryIcon: Record<string, string> = {
+                    auth: '🔐', payments: '💳', database: '🗄️',
+                    security: '🛡️', performance: '⚡', architecture: '🏗️',
+                  };
+                  const colorClass = categoryColor[insight.category] ?? categoryColor.architecture;
+                  return (
+                    <div key={i} className={`rounded-xl border p-4 ${colorClass}`}>
+                      <div className="flex items-start gap-2">
+                        <span className="text-base shrink-0">{categoryIcon[insight.category] ?? '🔍'}</span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold mb-0.5">{insight.finding}</p>
+                          <p className="text-xs opacity-80 font-mono mb-1.5 truncate">{insight.evidence}</p>
+                          <p className="text-xs opacity-90">{insight.recommendation}</p>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* API Routes discovered */}
+          {report.apiRoutes && report.apiRoutes.length > 0 && (
+            <div className="bg-white rounded-2xl border border-gray-100 p-6">
+              <h3 className="font-semibold text-gray-900 mb-3">
+                API routes found
+                <span className="ml-2 text-xs font-normal text-gray-400">({report.apiRoutes.length} total)</span>
+              </h3>
+              <div className="flex flex-wrap gap-1.5">
+                {report.apiRoutes.map(route => (
+                  <code key={route} className="text-xs bg-gray-50 border border-gray-200 text-gray-600 px-2 py-1 rounded-lg">
+                    {route}
+                  </code>
+                ))}
+              </div>
             </div>
           )}
 

--- a/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -8,16 +8,24 @@ import { Button } from '@/components/ui/button';
 type AnalysisReport = {
   detectedStack: {
     framework: string;
+    frameworkVersion?: string;
     language: string;
+    nodeVersion?: string | null;
     hasAuth: boolean;
     authProvider: string | null;
+    authDetails?: string | null;
     hasPayments: boolean;
     paymentsProvider: string | null;
+    paymentsDetails?: string | null;
     hasDatabase: boolean;
     dbProvider: string | null;
+    dbDetails?: string | null;
     hasCI: boolean;
+    ciDetails?: string | null;
+    otherDependencies?: string[];
   };
   pattern: string;
+  appDescription?: string;
   injectionOpportunities: Array<{
     layer: string;
     canInject: boolean;
@@ -25,13 +33,22 @@ type AnalysisReport = {
     proposed: string;
     filesToCreate: string[];
     effort: string;
+    gaps?: string[];
+    implementation?: string;
+    envVarsNeeded?: string[];
   }>;
   conflicts: Array<{
     description: string;
     severity: 'warning' | 'blocker';
     resolution: string;
+    affectedFiles?: string[];
   }>;
   summary: string;
+  monetizationReadiness?: {
+    score: number;
+    blockers: string[];
+    quickWins: string[];
+  };
 };
 
 type Project = {
@@ -294,12 +311,33 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
       {/* ANALYZED — report + config form */}
       {status === 'analyzed' && report && !injecting && (
         <div className="space-y-6">
-          {/* Summary */}
+          {/* Summary + monetization score */}
           <div className="bg-white rounded-2xl border border-gray-100 p-6">
-            <h2 className="font-semibold text-gray-900 mb-3">Analysis complete</h2>
-            <p className="text-sm text-gray-600 mb-4">{report.summary}</p>
-            <div className="flex flex-wrap gap-2">
-              <StackBadge label={report.detectedStack.framework} />
+            <div className="flex items-start justify-between gap-4 mb-4">
+              <div className="flex-1">
+                <h2 className="font-semibold text-gray-900 mb-1">Analysis complete</h2>
+                {report.appDescription && (
+                  <p className="text-sm text-gray-500 mb-3 italic">{report.appDescription}</p>
+                )}
+                <p className="text-sm text-gray-700">{report.summary}</p>
+              </div>
+              {report.monetizationReadiness && (
+                <div className="shrink-0 text-center">
+                  <div className={`w-16 h-16 rounded-2xl flex items-center justify-center text-2xl font-bold ${
+                    report.monetizationReadiness.score >= 70 ? 'bg-emerald-50 text-emerald-700' :
+                    report.monetizationReadiness.score >= 40 ? 'bg-amber-50 text-amber-700' :
+                    'bg-red-50 text-red-700'
+                  }`}>
+                    {report.monetizationReadiness.score}
+                  </div>
+                  <p className="text-xs text-gray-400 mt-1">Monetization<br/>readiness</p>
+                </div>
+              )}
+            </div>
+
+            {/* Stack badges */}
+            <div className="flex flex-wrap gap-2 mb-4">
+              <StackBadge label={`${report.detectedStack.framework}${report.detectedStack.frameworkVersion ? ` ${report.detectedStack.frameworkVersion}` : ''}`} />
               <StackBadge label={report.detectedStack.language.toUpperCase()} />
               {report.detectedStack.authProvider && <StackBadge label={`Auth: ${report.detectedStack.authProvider}`} color="amber" />}
               {report.detectedStack.dbProvider && <StackBadge label={`DB: ${report.detectedStack.dbProvider}`} color="amber" />}
@@ -307,7 +345,36 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
               {!report.detectedStack.hasAuth && <StackBadge label="No auth" color="red" />}
               {!report.detectedStack.hasPayments && <StackBadge label="No payments" color="red" />}
               {!report.detectedStack.hasDatabase && <StackBadge label="No database" color="red" />}
+              {report.detectedStack.otherDependencies?.map(dep => (
+                <StackBadge key={dep} label={dep} color="gray" />
+              ))}
             </div>
+
+            {/* Monetization blockers + quick wins */}
+            {report.monetizationReadiness && (
+              <div className="grid grid-cols-2 gap-3 mt-4 pt-4 border-t border-gray-50">
+                <div>
+                  <p className="text-xs font-semibold text-red-600 mb-2">🚧 Blockers before monetizing</p>
+                  <ul className="space-y-1">
+                    {report.monetizationReadiness.blockers.map((b, i) => (
+                      <li key={i} className="text-xs text-gray-600 flex gap-1.5">
+                        <span className="text-red-400 shrink-0">•</span>{b}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-emerald-600 mb-2">⚡ Quick wins Prodify can inject</p>
+                  <ul className="space-y-1">
+                    {report.monetizationReadiness.quickWins.map((w, i) => (
+                      <li key={i} className="text-xs text-gray-600 flex gap-1.5">
+                        <span className="text-emerald-400 shrink-0">•</span>{w}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Conflicts / warnings */}
@@ -319,47 +386,100 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
                   className={`rounded-xl p-4 flex gap-3 ${c.severity === 'blocker' ? 'bg-red-50 border border-red-200' : 'bg-amber-50 border border-amber-200'}`}
                 >
                   <span className="text-lg shrink-0">{c.severity === 'blocker' ? '🚫' : '⚠️'}</span>
-                  <div>
+                  <div className="flex-1">
                     <p className={`text-sm font-medium ${c.severity === 'blocker' ? 'text-red-800' : 'text-amber-800'}`}>{c.description}</p>
                     <p className={`text-xs mt-0.5 ${c.severity === 'blocker' ? 'text-red-600' : 'text-amber-600'}`}>Resolution: {c.resolution}</p>
+                    {c.affectedFiles && c.affectedFiles.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-2">
+                        {c.affectedFiles.map(f => (
+                          <code key={f} className="text-xs bg-white border border-red-200 text-red-700 px-1.5 py-0.5 rounded">{f}</code>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </div>
               ))}
             </div>
           )}
 
-          {/* Injection opportunities */}
-          <div className="bg-white rounded-2xl border border-gray-100 p-6">
-            <h3 className="font-semibold text-gray-900 mb-4">What will be injected</h3>
-            <div className="space-y-3">
-              {report.injectionOpportunities.map((opp, i) => (
-                <div key={i} className={`rounded-xl p-4 border ${opp.canInject ? 'border-gray-100' : 'border-gray-100 opacity-60'}`}>
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-lg">{LAYER_ICONS[opp.layer] ?? '📦'}</span>
-                    <span className="font-medium text-sm text-gray-900 capitalize">{opp.layer}</span>
-                    <span className={`ml-auto text-xs font-medium px-2 py-0.5 rounded-full ${EFFORT_COLOR[opp.effort] ?? 'text-gray-600 bg-gray-100'}`}>
-                      {opp.effort} effort
-                    </span>
-                    {opp.canInject
-                      ? <span className="text-xs text-emerald-600 font-medium">✓ Will inject</span>
-                      : <span className="text-xs text-gray-400">Already present</span>
-                    }
+          {/* Injection opportunities — detailed */}
+          <div className="space-y-4">
+            <h3 className="font-semibold text-gray-900">What will be injected</h3>
+            {report.injectionOpportunities.map((opp, i) => (
+              <div key={i} className={`bg-white rounded-2xl border p-5 ${opp.canInject ? 'border-gray-100' : 'border-gray-100 opacity-60'}`}>
+                {/* Header */}
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="text-xl">{LAYER_ICONS[opp.layer] ?? '📦'}</span>
+                  <span className="font-semibold text-gray-900 capitalize">{opp.layer}</span>
+                  <span className={`ml-auto text-xs font-medium px-2 py-0.5 rounded-full ${EFFORT_COLOR[opp.effort] ?? 'text-gray-600 bg-gray-100'}`}>
+                    {opp.effort} effort
+                  </span>
+                  {opp.canInject
+                    ? <span className="text-xs text-emerald-600 font-medium bg-emerald-50 px-2 py-0.5 rounded-full">✓ Will inject</span>
+                    : <span className="text-xs text-gray-400 bg-gray-50 px-2 py-0.5 rounded-full">Already present</span>
+                  }
+                </div>
+
+                {/* Current → Proposed */}
+                <div className="flex items-start gap-2 text-xs mb-3 p-3 bg-gray-50 rounded-xl">
+                  <div className="flex-1">
+                    <p className="text-gray-400 font-medium mb-0.5">CURRENT</p>
+                    <p className="text-gray-600">{opp.currentState}</p>
                   </div>
-                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-1">
-                    <span className="line-through">{opp.currentState}</span>
-                    <span>→</span>
-                    <span className="text-gray-700">{opp.proposed}</span>
+                  <span className="text-gray-300 mt-4">→</span>
+                  <div className="flex-1">
+                    <p className="text-violet-500 font-medium mb-0.5">AFTER INJECTION</p>
+                    <p className="text-gray-700">{opp.proposed}</p>
                   </div>
-                  {opp.filesToCreate.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
+                </div>
+
+                {/* Gaps */}
+                {opp.gaps && opp.gaps.length > 0 && (
+                  <div className="mb-3">
+                    <p className="text-xs font-semibold text-gray-500 mb-1.5">Missing pieces</p>
+                    <ul className="space-y-1">
+                      {opp.gaps.map((gap, j) => (
+                        <li key={j} className="text-xs text-gray-600 flex gap-1.5">
+                          <span className="text-red-400 shrink-0">✗</span>{gap}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Implementation detail */}
+                {opp.implementation && (
+                  <div className="mb-3">
+                    <p className="text-xs font-semibold text-gray-500 mb-1.5">What Prodify will build</p>
+                    <p className="text-xs text-gray-600 leading-relaxed">{opp.implementation}</p>
+                  </div>
+                )}
+
+                {/* Files to create */}
+                {opp.filesToCreate.length > 0 && (
+                  <div className="mb-3">
+                    <p className="text-xs font-semibold text-gray-500 mb-1.5">Files that will be created</p>
+                    <div className="flex flex-wrap gap-1">
                       {opp.filesToCreate.map(f => (
                         <code key={f} className="text-xs bg-gray-50 border border-gray-200 text-gray-600 px-1.5 py-0.5 rounded">{f}</code>
                       ))}
                     </div>
-                  )}
-                </div>
-              ))}
-            </div>
+                  </div>
+                )}
+
+                {/* Env vars needed */}
+                {opp.envVarsNeeded && opp.envVarsNeeded.length > 0 && (
+                  <div>
+                    <p className="text-xs font-semibold text-gray-500 mb-1.5">Env vars you'll need to add</p>
+                    <div className="flex flex-wrap gap-1">
+                      {opp.envVarsNeeded.map(v => (
+                        <code key={v} className="text-xs bg-amber-50 border border-amber-200 text-amber-700 px-1.5 py-0.5 rounded">{v}</code>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
 
           {/* Config form */}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSession, signOut } from 'next-auth/react';
+import { signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -28,12 +29,20 @@ function Section({ children }: { children: React.ReactNode }) {
   return <div className="space-y-6">{children}</div>;
 }
 
+type GitHubStatus = {
+  connected: boolean;
+  login?: string;
+  avatar?: string;
+};
+
 export default function SettingsPage() {
   const { data: session, update } = useSession();
   const [profileSaved, setProfileSaved] = useState(false);
   const [passwordMsg, setPasswordMsg] = useState('');
   const [passwordError, setPasswordError] = useState('');
-  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'danger'>('profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'accounts' | 'danger'>('profile');
+  const [githubStatus, setGithubStatus] = useState<GitHubStatus | null>(null);
+  const [disconnecting, setDisconnecting] = useState(false);
 
   const initials = session?.user?.name?.slice(0, 2).toUpperCase() ?? 'U';
 
@@ -45,6 +54,16 @@ export default function SettingsPage() {
   const { register: regPw, handleSubmit: hsPw, reset: resetPw, formState: { errors: errPw, isSubmitting: submPw } } = useForm<PasswordData>({
     resolver: zodResolver(passwordSchema),
   });
+
+  const fetchGithubStatus = useCallback(async () => {
+    const res = await fetch('/api/github/status');
+    if (res.ok) {
+      const data = await res.json() as GitHubStatus;
+      setGithubStatus(data);
+    }
+  }, []);
+
+  useEffect(() => { void fetchGithubStatus(); }, [fetchGithubStatus]);
 
   async function onProfileSubmit(data: ProfileData) {
     await fetch('/api/user/profile', {
@@ -74,9 +93,19 @@ export default function SettingsPage() {
     }
   }
 
+  async function disconnectGitHub() {
+    setDisconnecting(true);
+    const res = await fetch('/api/github/disconnect', { method: 'DELETE' });
+    if (res.ok) {
+      setGithubStatus({ connected: false });
+    }
+    setDisconnecting(false);
+  }
+
   const TABS = [
     { key: 'profile', label: 'Profile' },
     { key: 'password', label: 'Password' },
+    { key: 'accounts', label: 'Connected Accounts' },
     { key: 'danger', label: 'Danger Zone' },
   ] as const;
 
@@ -178,6 +207,70 @@ export default function SettingsPage() {
                   {submPw ? 'Updating...' : 'Update password'}
                 </Button>
               </form>
+            </CardContent>
+          </Card>
+        </Section>
+      )}
+
+      {/* Connected Accounts tab */}
+      {activeTab === 'accounts' && (
+        <Section>
+          <Card>
+            <CardHeader>
+              <CardTitle>Connected Accounts</CardTitle>
+              <CardDescription>Manage third-party integrations used by Prodify</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* GitHub */}
+              <div className="flex items-center justify-between p-4 rounded-xl border border-gray-100 bg-gray-50">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-lg bg-gray-900 flex items-center justify-center shrink-0">
+                    <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+                    </svg>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">GitHub</p>
+                    {githubStatus?.connected && githubStatus.login ? (
+                      <div className="flex items-center gap-1.5 mt-0.5">
+                        {githubStatus.avatar && (
+                          <img src={githubStatus.avatar} alt="" className="w-4 h-4 rounded-full" />
+                        )}
+                        <p className="text-xs text-gray-500">@{githubStatus.login}</p>
+                        <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block" />
+                        <span className="text-xs text-emerald-600 font-medium">Connected</span>
+                      </div>
+                    ) : (
+                      <p className="text-xs text-gray-400 mt-0.5">Not connected</p>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  {githubStatus?.connected ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={disconnecting}
+                      onClick={() => void disconnectGitHub()}
+                      className="text-xs border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300"
+                    >
+                      {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => void signIn('github', { callbackUrl: '/settings' })}
+                      className="text-xs bg-gray-900 hover:bg-gray-800 text-white"
+                    >
+                      Connect GitHub
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <p className="text-xs text-gray-400 px-1">
+                GitHub is used to import repos, clone them for analysis, push injection branches, and open pull requests. Disconnecting will not affect existing projects.
+              </p>
             </CardContent>
           </Card>
         </Section>

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession, signOut } from 'next-auth/react';
-import { signIn } from 'next-auth/react';
+import { useSession, signOut, signIn } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -11,6 +10,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
 
 const profileSchema = z.object({ name: z.string().min(1, 'Name is required').max(64) });
 type ProfileData = z.infer<typeof profileSchema>;
@@ -25,45 +26,109 @@ const passwordSchema = z.object({
 });
 type PasswordData = z.infer<typeof passwordSchema>;
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type GitHubStatus = { connected: boolean; login?: string; avatar?: string };
+
+type ApiKey = {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt?: string | null;
+  token?: string; // only present immediately after creation
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
 function Section({ children }: { children: React.ReactNode }) {
   return <div className="space-y-6">{children}</div>;
 }
 
-type GitHubStatus = {
-  connected: boolean;
-  login?: string;
-  avatar?: string;
-};
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86400_000);
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function SettingsPage() {
   const { data: session, update } = useSession();
+  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'accounts' | 'apikeys' | 'danger'>('profile');
+
+  // Profile
   const [profileSaved, setProfileSaved] = useState(false);
+
+  // Password
   const [passwordMsg, setPasswordMsg] = useState('');
   const [passwordError, setPasswordError] = useState('');
-  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'accounts' | 'danger'>('profile');
+
+  // GitHub
   const [githubStatus, setGithubStatus] = useState<GitHubStatus | null>(null);
   const [disconnecting, setDisconnecting] = useState(false);
 
+  // API Keys
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [keysLoading, setKeysLoading] = useState(false);
+  const [newKeyToken, setNewKeyToken] = useState<string | null>(null);
+  const [newKeyCopied, setNewKeyCopied] = useState(false);
+  const [generatingKey, setGeneratingKey] = useState(false);
+  const [keyError, setKeyError] = useState('');
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  // Danger zone
+  const [deleteConfirm, setDeleteConfirm] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
+
   const initials = session?.user?.name?.slice(0, 2).toUpperCase() ?? 'U';
 
-  const { register: regP, handleSubmit: hsP, formState: { errors: errP, isSubmitting: submP } } = useForm<ProfileData>({
+  // ── Forms ──────────────────────────────────────────────────────────────────
+
+  const {
+    register: regP,
+    handleSubmit: hsP,
+    formState: { errors: errP, isSubmitting: submP },
+  } = useForm<ProfileData>({
     resolver: zodResolver(profileSchema),
     defaultValues: { name: session?.user?.name ?? '' },
   });
 
-  const { register: regPw, handleSubmit: hsPw, reset: resetPw, formState: { errors: errPw, isSubmitting: submPw } } = useForm<PasswordData>({
-    resolver: zodResolver(passwordSchema),
-  });
+  const {
+    register: regPw,
+    handleSubmit: hsPw,
+    reset: resetPw,
+    formState: { errors: errPw, isSubmitting: submPw },
+  } = useForm<PasswordData>({ resolver: zodResolver(passwordSchema) });
+
+  // ── Data fetching ──────────────────────────────────────────────────────────
 
   const fetchGithubStatus = useCallback(async () => {
     const res = await fetch('/api/github/status');
+    if (res.ok) setGithubStatus(await res.json() as GitHubStatus);
+  }, []);
+
+  const fetchApiKeys = useCallback(async () => {
+    setKeysLoading(true);
+    const res = await fetch('/api/user/api-keys');
     if (res.ok) {
-      const data = await res.json() as GitHubStatus;
-      setGithubStatus(data);
+      const data = await res.json() as { keys: ApiKey[] };
+      setApiKeys(data.keys);
     }
+    setKeysLoading(false);
   }, []);
 
   useEffect(() => { void fetchGithubStatus(); }, [fetchGithubStatus]);
+  useEffect(() => {
+    if (activeTab === 'apikeys') void fetchApiKeys();
+  }, [activeTab, fetchApiKeys]);
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
 
   async function onProfileSubmit(data: ProfileData) {
     await fetch('/api/user/profile', {
@@ -96,17 +161,59 @@ export default function SettingsPage() {
   async function disconnectGitHub() {
     setDisconnecting(true);
     const res = await fetch('/api/github/disconnect', { method: 'DELETE' });
-    if (res.ok) {
-      setGithubStatus({ connected: false });
-    }
+    if (res.ok) setGithubStatus({ connected: false });
     setDisconnecting(false);
   }
 
+  async function generateApiKey() {
+    setGeneratingKey(true);
+    setKeyError('');
+    setNewKeyToken(null);
+    const res = await fetch('/api/user/api-keys', { method: 'POST' });
+    const data = await res.json() as { key?: ApiKey; error?: string };
+    if (!res.ok || !data.key) {
+      setKeyError(data.error ?? 'Failed to generate key');
+    } else {
+      setNewKeyToken(data.key.token ?? null);
+      setApiKeys(prev => [data.key!, ...prev]);
+    }
+    setGeneratingKey(false);
+  }
+
+  async function revokeKey(id: string) {
+    setRevokingId(id);
+    const res = await fetch(`/api/user/api-keys/${id}`, { method: 'DELETE' });
+    if (res.ok) setApiKeys(prev => prev.filter(k => k.id !== id));
+    setRevokingId(null);
+  }
+
+  async function copyToken(token: string) {
+    await navigator.clipboard.writeText(token);
+    setNewKeyCopied(true);
+    setTimeout(() => setNewKeyCopied(false), 2000);
+  }
+
+  async function deleteAccount() {
+    setDeleting(true);
+    setDeleteError('');
+    const res = await fetch('/api/user/delete', { method: 'DELETE' });
+    if (res.ok) {
+      await signOut({ callbackUrl: '/login' });
+    } else {
+      const j = await res.json() as { error?: string };
+      setDeleteError(j.error ?? 'Failed to delete account.');
+      setDeleting(false);
+    }
+  }
+
+  // ── Tabs ───────────────────────────────────────────────────────────────────
+
   const TABS = [
-    { key: 'profile', label: 'Profile' },
+    { key: 'profile',  label: 'Profile' },
     { key: 'password', label: 'Password' },
     { key: 'accounts', label: 'Connected Accounts' },
-    { key: 'danger', label: 'Danger Zone' },
+    { key: 'apikeys',  label: 'API Keys' },
+    { key: 'danger',   label: 'Danger Zone' },
   ] as const;
 
   return (
@@ -117,12 +224,12 @@ export default function SettingsPage() {
       </div>
 
       {/* Tab nav */}
-      <div className="flex gap-1 border-b border-gray-200 mb-6">
+      <div className="flex gap-1 border-b border-gray-200 mb-6 overflow-x-auto">
         {TABS.map(tab => (
           <button
             key={tab.key}
             onClick={() => setActiveTab(tab.key)}
-            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px whitespace-nowrap ${
               activeTab === tab.key
                 ? 'border-violet-600 text-violet-700'
                 : 'border-transparent text-gray-500 hover:text-gray-700'
@@ -133,7 +240,7 @@ export default function SettingsPage() {
         ))}
       </div>
 
-      {/* Profile tab */}
+      {/* ── Profile ─────────────────────────────────────────────────────────── */}
       {activeTab === 'profile' && (
         <Section>
           <Card>
@@ -176,13 +283,13 @@ export default function SettingsPage() {
         </Section>
       )}
 
-      {/* Password tab */}
+      {/* ── Password ────────────────────────────────────────────────────────── */}
       {activeTab === 'password' && (
         <Section>
           <Card>
             <CardHeader>
               <CardTitle>Change Password</CardTitle>
-              <CardDescription>Update your account password. Leave blank to keep current.</CardDescription>
+              <CardDescription>Update your account password.</CardDescription>
             </CardHeader>
             <CardContent>
               <form onSubmit={hsPw(onPasswordSubmit)} className="space-y-4">
@@ -212,7 +319,7 @@ export default function SettingsPage() {
         </Section>
       )}
 
-      {/* Connected Accounts tab */}
+      {/* ── Connected Accounts ──────────────────────────────────────────────── */}
       {activeTab === 'accounts' && (
         <Section>
           <Card>
@@ -221,7 +328,6 @@ export default function SettingsPage() {
               <CardDescription>Manage third-party integrations used by Prodify</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {/* GitHub */}
               <div className="flex items-center justify-between p-4 rounded-xl border border-gray-100 bg-gray-50">
                 <div className="flex items-center gap-3">
                   <div className="w-9 h-9 rounded-lg bg-gray-900 flex items-center justify-center shrink-0">
@@ -245,29 +351,26 @@ export default function SettingsPage() {
                     )}
                   </div>
                 </div>
-                <div>
-                  {githubStatus?.connected ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={disconnecting}
-                      onClick={() => void disconnectGitHub()}
-                      className="text-xs border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300"
-                    >
-                      {disconnecting ? 'Disconnecting...' : 'Disconnect'}
-                    </Button>
-                  ) : (
-                    <Button
-                      size="sm"
-                      onClick={() => void signIn('github', { callbackUrl: '/settings' })}
-                      className="text-xs bg-gray-900 hover:bg-gray-800 text-white"
-                    >
-                      Connect GitHub
-                    </Button>
-                  )}
-                </div>
+                {githubStatus?.connected ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disconnecting}
+                    onClick={() => void disconnectGitHub()}
+                    className="text-xs border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300"
+                  >
+                    {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    onClick={() => void signIn('github', { callbackUrl: '/settings' })}
+                    className="text-xs bg-gray-900 hover:bg-gray-800 text-white"
+                  >
+                    Connect GitHub
+                  </Button>
+                )}
               </div>
-
               <p className="text-xs text-gray-400 px-1">
                 GitHub is used to import repos, clone them for analysis, push injection branches, and open pull requests. Disconnecting will not affect existing projects.
               </p>
@@ -276,7 +379,95 @@ export default function SettingsPage() {
         </Section>
       )}
 
-      {/* Danger zone tab */}
+      {/* ── API Keys ────────────────────────────────────────────────────────── */}
+      {activeTab === 'apikeys' && (
+        <Section>
+          <Card>
+            <CardHeader>
+              <CardTitle>API Keys</CardTitle>
+              <CardDescription>
+                Use these keys to authenticate with the Prodify CLI and API. Keys are shown once — store them securely.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* New key reveal banner */}
+              {newKeyToken && (
+                <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4">
+                  <p className="text-xs font-semibold text-emerald-800 mb-2">
+                    ✓ New key generated — copy it now, it won&apos;t be shown again
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 text-xs bg-white border border-emerald-200 rounded-lg px-3 py-2 font-mono text-gray-800 truncate">
+                      {newKeyToken}
+                    </code>
+                    <button
+                      onClick={() => void copyToken(newKeyToken)}
+                      className="shrink-0 text-xs font-medium text-emerald-700 border border-emerald-300 hover:bg-emerald-100 px-3 py-2 rounded-lg transition-colors"
+                    >
+                      {newKeyCopied ? '✓ Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Key list */}
+              {keysLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="w-5 h-5 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : apiKeys.length === 0 ? (
+                <div className="text-center py-8 text-gray-400 text-sm border border-dashed border-gray-200 rounded-xl">
+                  No API keys yet. Generate one below.
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-50 border border-gray-100 rounded-xl overflow-hidden">
+                  {apiKeys.map(key => (
+                    <div key={key.id} className="flex items-center gap-3 px-4 py-3 bg-white">
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-900">{key.name}</p>
+                        <div className="flex items-center gap-2 mt-0.5">
+                          <code className="text-xs text-gray-400 font-mono">{key.prefix}••••••••</code>
+                          <span className="text-gray-300">·</span>
+                          <span className="text-xs text-gray-400">Created {timeAgo(key.createdAt)}</span>
+                          {key.lastUsedAt && (
+                            <>
+                              <span className="text-gray-300">·</span>
+                              <span className="text-xs text-gray-400">Last used {timeAgo(key.lastUsedAt)}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => void revokeKey(key.id)}
+                        disabled={revokingId === key.id}
+                        className="text-xs text-red-500 hover:text-red-700 font-medium transition-colors disabled:opacity-50"
+                      >
+                        {revokingId === key.id ? 'Revoking...' : 'Revoke'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {keyError && <p className="text-sm text-red-500">{keyError}</p>}
+
+              <div className="flex items-center justify-between pt-2">
+                <p className="text-xs text-gray-400">Up to 5 keys per account</p>
+                <Button
+                  onClick={() => void generateApiKey()}
+                  disabled={generatingKey || apiKeys.length >= 5}
+                  className="bg-violet-600 hover:bg-violet-700 text-white text-xs"
+                  size="sm"
+                >
+                  {generatingKey ? 'Generating...' : '+ Generate new key'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </Section>
+      )}
+
+      {/* ── Danger Zone ─────────────────────────────────────────────────────── */}
       {activeTab === 'danger' && (
         <Section>
           <Card className="border-red-200">
@@ -285,6 +476,7 @@ export default function SettingsPage() {
               <CardDescription>Irreversible actions. Proceed with caution.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
+              {/* Sign out everywhere */}
               <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-100">
                 <div>
                   <p className="text-sm font-medium text-gray-900">Sign out everywhere</p>
@@ -298,17 +490,35 @@ export default function SettingsPage() {
                   Sign out
                 </Button>
               </div>
-              <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-100">
+
+              {/* Delete account */}
+              <div className="p-4 bg-red-50 rounded-lg border border-red-100 space-y-3">
                 <div>
                   <p className="text-sm font-medium text-gray-900">Delete account</p>
-                  <p className="text-xs text-gray-500 mt-0.5">Permanently delete your account and all data. Cannot be undone.</p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    Permanently deletes your account, all projects, activity history, GitHub connection, and API keys. This cannot be undone.
+                  </p>
                 </div>
+                <div className="space-y-2">
+                  <Label htmlFor="delete-confirm" className="text-xs text-gray-600">
+                    Type <span className="font-mono font-semibold text-red-700">delete my account</span> to confirm
+                  </Label>
+                  <Input
+                    id="delete-confirm"
+                    value={deleteConfirm}
+                    onChange={e => setDeleteConfirm(e.target.value)}
+                    placeholder="delete my account"
+                    className="border-red-200 focus:border-red-400 focus:ring-red-200 text-sm"
+                  />
+                </div>
+                {deleteError && <p className="text-sm text-red-600">{deleteError}</p>}
                 <Button
                   variant="outline"
-                  className="border-red-300 text-red-700 hover:bg-red-100"
-                  onClick={() => alert('Account deletion coming soon. Contact support@prodify.app')}
+                  disabled={deleteConfirm !== 'delete my account' || deleting}
+                  onClick={() => void deleteAccount()}
+                  className="border-red-400 text-red-700 hover:bg-red-100 disabled:opacity-40"
                 >
-                  Delete account
+                  {deleting ? 'Deleting...' : 'Delete my account'}
                 </Button>
               </div>
             </CardContent>

--- a/apps/web/app/api/activity/route.ts
+++ b/apps/web/app/api/activity/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: events, error } = await insforge.database
+    .from('activity_events')
+    .select('id, type, message, projectId, projectName, metadata, createdAt')
+    .eq('userId', session.user.id)
+    .order('createdAt', { ascending: false })
+    .limit(20);
+
+  if (error) {
+    return NextResponse.json({ events: [] });
+  }
+
+  return NextResponse.json({ events: events ?? [] });
+}

--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -26,9 +26,10 @@ export async function POST(req: NextRequest) {
     if (error) {
       // Map InsForge error codes to user-friendly messages
       const msg = error.message ?? "Something went wrong";
+      const rawStatus = (error as { statusCode?: number }).statusCode;
       const status =
-        typeof (error as { statusCode?: number }).statusCode === "number"
-          ? (error as { statusCode?: number }).statusCode!
+        typeof rawStatus === "number" && rawStatus >= 200 && rawStatus <= 599
+          ? rawStatus
           : 400;
       return NextResponse.json({ error: msg }, { status });
     }

--- a/apps/web/app/api/github/disconnect/route.ts
+++ b/apps/web/app/api/github/disconnect/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+export async function DELETE() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { error } = await insforge.database
+    .from('github_connections')
+    .delete()
+    .eq('userId', session.user.id);
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to disconnect GitHub' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/github/repos/route.ts
+++ b/apps/web/app/api/github/repos/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Get stored GitHub access token
+  const { data: conn } = await insforge.database
+    .from('github_connections')
+    .select('access_token, github_login')
+    .eq('userId', session.user.id)
+    .single();
+
+  if (!conn) {
+    return NextResponse.json({ connected: false, repos: [] });
+  }
+
+  const res = await fetch(
+    'https://api.github.com/user/repos?sort=pushed&per_page=100&type=owner',
+    {
+      headers: {
+        Authorization: `Bearer ${conn.access_token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to fetch repos from GitHub' }, { status: 502 });
+  }
+
+  const raw = await res.json() as Array<{
+    id: number;
+    name: string;
+    full_name: string;
+    description: string | null;
+    html_url: string;
+    clone_url: string;
+    language: string | null;
+    stargazers_count: number;
+    pushed_at: string;
+    private: boolean;
+    default_branch: string;
+  }>;
+
+  const repos = raw.map(r => ({
+    id: r.id,
+    name: r.name,
+    fullName: r.full_name,
+    description: r.description,
+    url: r.html_url,
+    cloneUrl: r.clone_url,
+    language: r.language,
+    stars: r.stargazers_count,
+    pushedAt: r.pushed_at,
+    private: r.private,
+    defaultBranch: r.default_branch,
+  }));
+
+  return NextResponse.json({ connected: true, login: conn.github_login, repos });
+}

--- a/apps/web/app/api/github/status/route.ts
+++ b/apps/web/app/api/github/status/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: conn } = await insforge.database
+    .from('github_connections')
+    .select('github_login, github_avatar, createdAt')
+    .eq('userId', session.user.id)
+    .single();
+
+  if (!conn) {
+    return NextResponse.json({ connected: false });
+  }
+
+  return NextResponse.json({
+    connected: true,
+    login: conn.github_login,
+    avatar: conn.github_avatar,
+  });
+}

--- a/apps/web/app/api/projects/[id]/analyze/route.ts
+++ b/apps/web/app/api/projects/[id]/analyze/route.ts
@@ -7,7 +7,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import { simpleGit } from 'simple-git';
-import { analyzeRepository } from '@prodify/injector/src/ai/analyzer';
+import { scanRepository, analyzeWithAI, computeCacheKey, buildFallbackReport } from '@prodify/injector/src/ai/analyzer';
 
 function send(controller: ReadableStreamDefaultController, event: string, data: unknown) {
   const encoded = new TextEncoder().encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -25,7 +25,6 @@ export async function POST(
 
   const { id } = await params;
 
-  // Verify project belongs to user
   const { data: project } = await insforge.database
     .from('projects')
     .select('*')
@@ -36,7 +35,6 @@ export async function POST(
   if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   if (!project.cloneUrl) return NextResponse.json({ error: 'No repo URL on this project' }, { status: 400 });
 
-  // Get GitHub access token for private repos
   const { data: conn } = await insforge.database
     .from('github_connections')
     .select('access_token')
@@ -49,11 +47,16 @@ export async function POST(
 
       try {
         await insforge.database.from('projects').update({ status: 'analyzing' }).eq('id', id);
-        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_started', message: `Started analyzing ${project.repoFullName ?? project.name}` });
+        await logActivity({
+          userId: session.user.id,
+          projectId: id,
+          projectName: project.name as string,
+          type: 'analysis_started',
+          message: `Started analyzing ${project.repoFullName ?? project.name}`,
+        });
 
-        send(controller, 'progress', { step: 1, total: 4, message: 'Cloning repository...' });
+        send(controller, 'progress', { step: 1, total: 5, message: 'Cloning repository...' });
 
-        // Build clone URL with auth token if available
         let cloneUrl = project.cloneUrl as string;
         if (conn?.access_token) {
           cloneUrl = cloneUrl.replace('https://', `https://${conn.access_token}@`);
@@ -62,25 +65,71 @@ export async function POST(
         const git = simpleGit();
         await git.clone(cloneUrl, tmpDir, ['--depth=1']);
 
-        send(controller, 'progress', { step: 2, total: 4, message: 'Reading project files...' });
+        send(controller, 'progress', { step: 2, total: 5, message: 'Scanning project files...' });
 
-        send(controller, 'progress', { step: 3, total: 4, message: 'Analyzing with AI (AWS Bedrock)...' });
+        // Phase 1: free programmatic scan
+        const fingerprint = await scanRepository(tmpDir);
 
-        const report = await analyzeRepository(tmpDir);
+        // Get HEAD commit SHA for cache key
+        let headSha = 'unknown';
+        try {
+          const repoGit = simpleGit(tmpDir);
+          headSha = (await repoGit.revparse(['HEAD'])).trim();
+        } catch { /* non-fatal */ }
 
-        send(controller, 'progress', { step: 4, total: 4, message: 'Saving results...' });
+        // Cache check: if project already has an analysis for this exact repo state, return it
+        const cacheKey = computeCacheKey(project.cloneUrl as string, headSha, fingerprint.packageJsonHash);
+        const existingResult = project.analysisResult as (Record<string, unknown> & { _cacheKey?: string }) | null;
 
-        await insforge.database.from('projects').update({ status: 'analyzed', analysisResult: report }).eq('id', id);
-        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_completed', message: `Analysis complete — ${report.detectedStack.framework}, ${report.injectionOpportunities.filter(o => o.canInject).length} layers ready to inject`, metadata: { pattern: report.pattern } });
+        if (existingResult?._cacheKey === cacheKey) {
+          send(controller, 'progress', { step: 5, total: 5, message: 'Returning cached analysis...' });
+          send(controller, 'done', { report: existingResult, cached: true });
+          controller.close();
+          return;
+        }
+
+        send(controller, 'progress', { step: 3, total: 5, message: 'Understanding app structure (Haiku)...' });
+
+        // Phase 2 + 3: AI analysis (Haiku → Sonnet)
+        send(controller, 'progress', { step: 4, total: 5, message: 'Deep analysis in progress (Sonnet)...' });
+
+        const report = await analyzeWithAI(tmpDir, fingerprint);
+
+        send(controller, 'progress', { step: 5, total: 5, message: 'Saving results...' });
+
+        // Embed cache key inside the stored result (no schema migration needed)
+        const reportWithCache = { ...report, _cacheKey: cacheKey };
+
+        await insforge.database
+          .from('projects')
+          .update({ status: 'analyzed', analysisResult: reportWithCache })
+          .eq('id', id);
+
+        await logActivity({
+          userId: session.user.id,
+          projectId: id,
+          projectName: project.name as string,
+          type: 'analysis_completed',
+          message: `Analysis complete — ${report.detectedStack.framework}, ${report.injectionOpportunities.filter(o => o.canInject).length} layers ready to inject`,
+          metadata: { pattern: report.pattern },
+        });
 
         send(controller, 'done', { report });
       } catch (err) {
         console.error('[analyze] error:', err);
         await insforge.database.from('projects').update({ status: 'error' }).eq('id', id);
-        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_failed', message: `Analysis failed: ${err instanceof Error ? err.message : 'Unknown error'}` });
-        send(controller, 'error', { message: err instanceof Error ? err.message : 'Analysis failed' });
+        await logActivity({
+          userId: session.user.id,
+          projectId: id,
+          projectName: project.name as string,
+          type: 'analysis_failed',
+          message: `Analysis failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        });
+
+        // Return fallback report so the UI still works
+        const fallback = buildFallbackReport();
+        send(controller, 'error', { message: err instanceof Error ? err.message : 'Analysis failed', fallback });
       } finally {
-        // Clean up temp dir
         try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
         controller.close();
       }

--- a/apps/web/app/api/projects/[id]/analyze/route.ts
+++ b/apps/web/app/api/projects/[id]/analyze/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { simpleGit } from 'simple-git';
+import { analyzeRepository } from '@prodify/injector/src/ai/analyzer';
+
+function send(controller: ReadableStreamDefaultController, event: string, data: unknown) {
+  const encoded = new TextEncoder().encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  controller.enqueue(encoded);
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Verify project belongs to user
+  const { data: project } = await insforge.database
+    .from('projects')
+    .select('*')
+    .eq('id', id)
+    .eq('userId', session.user.id)
+    .single();
+
+  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (!project.cloneUrl) return NextResponse.json({ error: 'No repo URL on this project' }, { status: 400 });
+
+  // Get GitHub access token for private repos
+  const { data: conn } = await insforge.database
+    .from('github_connections')
+    .select('access_token')
+    .eq('userId', session.user.id)
+    .single();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const tmpDir = path.join(os.tmpdir(), `prodify-${id}-${Date.now()}`);
+
+      try {
+        // Update status to analyzing
+        await insforge.database
+          .from('projects')
+          .update({ status: 'analyzing' })
+          .eq('id', id);
+
+        send(controller, 'progress', { step: 1, total: 4, message: 'Cloning repository...' });
+
+        // Build clone URL with auth token if available
+        let cloneUrl = project.cloneUrl as string;
+        if (conn?.access_token) {
+          cloneUrl = cloneUrl.replace('https://', `https://${conn.access_token}@`);
+        }
+
+        const git = simpleGit();
+        await git.clone(cloneUrl, tmpDir, ['--depth=1']);
+
+        send(controller, 'progress', { step: 2, total: 4, message: 'Reading project files...' });
+
+        send(controller, 'progress', { step: 3, total: 4, message: 'Analyzing with AI (AWS Bedrock)...' });
+
+        const report = await analyzeRepository(tmpDir);
+
+        send(controller, 'progress', { step: 4, total: 4, message: 'Saving results...' });
+
+        await insforge.database
+          .from('projects')
+          .update({ status: 'analyzed', analysisResult: report })
+          .eq('id', id);
+
+        send(controller, 'done', { report });
+      } catch (err) {
+        console.error('[analyze] error:', err);
+        await insforge.database
+          .from('projects')
+          .update({ status: 'error' })
+          .eq('id', id);
+        send(controller, 'error', { message: err instanceof Error ? err.message : 'Analysis failed' });
+      } finally {
+        // Clean up temp dir
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/apps/web/app/api/projects/[id]/analyze/route.ts
+++ b/apps/web/app/api/projects/[id]/analyze/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { insforge } from '@/lib/insforge';
+import { logActivity } from '@/lib/activity';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -47,11 +48,8 @@ export async function POST(
       const tmpDir = path.join(os.tmpdir(), `prodify-${id}-${Date.now()}`);
 
       try {
-        // Update status to analyzing
-        await insforge.database
-          .from('projects')
-          .update({ status: 'analyzing' })
-          .eq('id', id);
+        await insforge.database.from('projects').update({ status: 'analyzing' }).eq('id', id);
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_started', message: `Started analyzing ${project.repoFullName ?? project.name}` });
 
         send(controller, 'progress', { step: 1, total: 4, message: 'Cloning repository...' });
 
@@ -72,18 +70,14 @@ export async function POST(
 
         send(controller, 'progress', { step: 4, total: 4, message: 'Saving results...' });
 
-        await insforge.database
-          .from('projects')
-          .update({ status: 'analyzed', analysisResult: report })
-          .eq('id', id);
+        await insforge.database.from('projects').update({ status: 'analyzed', analysisResult: report }).eq('id', id);
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_completed', message: `Analysis complete — ${report.detectedStack.framework}, ${report.injectionOpportunities.filter(o => o.canInject).length} layers ready to inject`, metadata: { pattern: report.pattern } });
 
         send(controller, 'done', { report });
       } catch (err) {
         console.error('[analyze] error:', err);
-        await insforge.database
-          .from('projects')
-          .update({ status: 'error' })
-          .eq('id', id);
+        await insforge.database.from('projects').update({ status: 'error' }).eq('id', id);
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'analysis_failed', message: `Analysis failed: ${err instanceof Error ? err.message : 'Unknown error'}` });
         send(controller, 'error', { message: err instanceof Error ? err.message : 'Analysis failed' });
       } finally {
         // Clean up temp dir

--- a/apps/web/app/api/projects/[id]/inject/route.ts
+++ b/apps/web/app/api/projects/[id]/inject/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { insforge } from '@/lib/insforge';
+import { logActivity } from '@/lib/activity';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -51,6 +52,7 @@ export async function POST(
 
       try {
         await insforge.database.from('projects').update({ status: 'injecting' }).eq('id', id);
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'injection_started', message: `Started injecting infrastructure into ${project.repoFullName ?? project.name}`, metadata: { pricingModel: body.pricingModel, userType: body.userType } });
 
         // Step 1: Clone
         send(controller, 'progress', { step: 1, total: 6, message: 'Cloning repository...' });
@@ -166,10 +168,12 @@ jobs:
           })
           .eq('id', id);
 
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: prUrl ? 'pr_opened' : 'injection_completed', message: prUrl ? `PR opened for ${project.repoFullName ?? project.name}` : `Branch ${branchName} pushed to GitHub`, metadata: { prUrl, branchName } });
         send(controller, 'done', { prUrl, branchName });
       } catch (err) {
         console.error('[inject] error:', err);
         await insforge.database.from('projects').update({ status: 'error' }).eq('id', id);
+        await logActivity({ userId: session.user.id, projectId: id, projectName: project.name as string, type: 'injection_failed', message: `Injection failed: ${err instanceof Error ? err.message : 'Unknown error'}` });
         send(controller, 'error', { message: err instanceof Error ? err.message : 'Injection failed' });
       } finally {
         try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }

--- a/apps/web/app/api/projects/[id]/inject/route.ts
+++ b/apps/web/app/api/projects/[id]/inject/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { simpleGit } from 'simple-git';
+import { buildAuthFiles } from '@prodify/injector/src/injectors/auth';
+import { buildDbFiles } from '@prodify/injector/src/injectors/db';
+import { buildPaymentsFiles } from '@prodify/injector/src/injectors/payments';
+import { buildReadmeFile } from '@prodify/injector/src/injectors/readme';
+import type { PricingModel, UserType, ProdifyAnswers } from '@prodify/injector/src/types';
+
+function send(controller: ReadableStreamDefaultController, event: string, data: unknown) {
+  controller.enqueue(new TextEncoder().encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await req.json() as { pricingModel: PricingModel; userType: UserType; openPR: boolean };
+
+  const { data: project } = await insforge.database
+    .from('projects')
+    .select('*')
+    .eq('id', id)
+    .eq('userId', session.user.id)
+    .single();
+
+  if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (!project.cloneUrl) return NextResponse.json({ error: 'No repo URL' }, { status: 400 });
+
+  const { data: conn } = await insforge.database
+    .from('github_connections')
+    .select('access_token, github_login')
+    .eq('userId', session.user.id)
+    .single();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const tmpDir = path.join(os.tmpdir(), `prodify-inject-${id}-${Date.now()}`);
+      const branchName = `prodify/inject-${Date.now()}`;
+
+      try {
+        await insforge.database.from('projects').update({ status: 'injecting' }).eq('id', id);
+
+        // Step 1: Clone
+        send(controller, 'progress', { step: 1, total: 6, message: 'Cloning repository...' });
+        let cloneUrl = project.cloneUrl as string;
+        if (conn?.access_token) {
+          cloneUrl = cloneUrl.replace('https://', `https://${conn.access_token}@`);
+        }
+        const git = simpleGit();
+        await git.clone(cloneUrl, tmpDir, ['--depth=1']);
+        const repoGit = simpleGit(tmpDir);
+
+        // Step 2: Create branch
+        send(controller, 'progress', { step: 2, total: 6, message: `Creating branch ${branchName}...` });
+        await repoGit.checkoutLocalBranch(branchName);
+
+        // Step 3: Build injection files
+        send(controller, 'progress', { step: 3, total: 6, message: 'Generating infrastructure files...' });
+        const answers: ProdifyAnswers = {
+          pricingModel: body.pricingModel,
+          userType: body.userType,
+          stack: 'nextjs',
+          autoDeploy: body.openPR,
+        };
+        const allFiles = [
+          ...buildAuthFiles(body.userType),
+          ...buildDbFiles(body.userType),
+          ...buildPaymentsFiles(body.pricingModel),
+          ...buildReadmeFile(answers),
+        ];
+
+        // Also inject GitHub Actions CI
+        const ciContent = `name: CI
+on:
+  push:
+    branches: [main, 'prodify/**']
+  pull_request:
+    branches: [main]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+`;
+        allFiles.push({ relativePath: '.github/workflows/ci.yml', content: ciContent });
+
+        // Write files
+        for (const file of allFiles) {
+          const fullPath = path.join(tmpDir, file.relativePath);
+          fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+          fs.writeFileSync(fullPath, file.content, 'utf-8');
+        }
+
+        // Step 4: Commit
+        send(controller, 'progress', { step: 4, total: 6, message: 'Committing files...' });
+        await repoGit.addConfig('user.name', 'Prodify Bot');
+        await repoGit.addConfig('user.email', 'bot@prodify.dev');
+        await repoGit.add('.');
+        await repoGit.commit(`feat: inject Prodify production infrastructure
+
+- Auth: NextAuth.js with InsForge backend (${body.userType})
+- Payments: Stripe ${body.pricingModel} billing
+- Database: InsForge SQL schema
+- CI: GitHub Actions typecheck + test
+- Docs: README-prodify.md with activation checklist`);
+
+        // Step 5: Push
+        send(controller, 'progress', { step: 5, total: 6, message: 'Pushing to GitHub...' });
+        let pushUrl = cloneUrl;
+        await repoGit.push(pushUrl, branchName);
+
+        // Step 6: Open PR if requested
+        let prUrl: string | null = null;
+        if (body.openPR && conn?.access_token && project.repoFullName) {
+          send(controller, 'progress', { step: 6, total: 6, message: 'Opening pull request...' });
+          const prRes = await fetch(`https://api.github.com/repos/${project.repoFullName}/pulls`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${conn.access_token}`,
+              Accept: 'application/vnd.github+json',
+              'Content-Type': 'application/json',
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+            body: JSON.stringify({
+              title: 'feat: Prodify — inject production-ready SaaS infrastructure',
+              body: `## Prodify Infrastructure Injection\n\nThis PR injects production-ready SaaS infrastructure into your project:\n\n- **Auth**: NextAuth.js with InsForge backend (${body.userType})\n- **Payments**: Stripe ${body.pricingModel} billing + webhooks\n- **Database**: InsForge SQL schema\n- **CI**: GitHub Actions typecheck + test\n\n### Before merging\n\n1. Add env vars from \`prodify-layer/README-prodify.md\`\n2. Run the InsForge SQL schema\n3. Review each injected file\n\n---\n*Generated by [Prodify](https://prodify.dev)*`,
+              head: branchName,
+              base: project.defaultBranch ?? 'main',
+            }),
+          });
+
+          if (prRes.ok) {
+            const pr = await prRes.json() as { html_url: string };
+            prUrl = pr.html_url;
+          }
+        } else {
+          send(controller, 'progress', { step: 6, total: 6, message: 'Branch pushed to GitHub.' });
+        }
+
+        await insforge.database
+          .from('projects')
+          .update({
+            status: 'injected',
+            branchName,
+            prUrl,
+            injectionConfig: { pricingModel: body.pricingModel, userType: body.userType, openPR: body.openPR },
+          })
+          .eq('id', id);
+
+        send(controller, 'done', { prUrl, branchName });
+      } catch (err) {
+        console.error('[inject] error:', err);
+        await insforge.database.from('projects').update({ status: 'error' }).eq('id', id);
+        send(controller, 'error', { message: err instanceof Error ? err.message : 'Injection failed' });
+      } finally {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/apps/web/app/api/projects/[id]/route.ts
+++ b/apps/web/app/api/projects/[id]/route.ts
@@ -5,6 +5,25 @@ import { insforge } from "@/lib/insforge";
 
 type Params = { params: Promise<{ id: string }> };
 
+export async function GET(_req: NextRequest, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const { data: project, error } = await insforge.database
+    .from('projects')
+    .select('*')
+    .eq('id', id)
+    .eq('userId', session.user.id)
+    .single();
+
+  if (error || !project)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  return NextResponse.json({ project });
+}
+
 export async function PATCH(req: NextRequest, { params }: Params) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id)

--- a/apps/web/app/api/projects/route.ts
+++ b/apps/web/app/api/projects/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
   const { data: projects, error } = await insforge.database
     .from('projects')
-    .select('*')
+    .select('id, name, description, repoUrl, repoFullName, status, prUrl, branchName, createdAt, updatedAt')
     .eq('userId', session.user.id)
     .order('createdAt', { ascending: false });
 
@@ -27,11 +27,27 @@ export async function POST(req: NextRequest) {
   if (!session?.user?.id)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = await req.json() as { name?: string; description?: string };
+  const body = await req.json() as {
+    name?: string;
+    description?: string;
+    repoUrl?: string;
+    repoFullName?: string;
+    cloneUrl?: string;
+    defaultBranch?: string;
+  };
+
   const name = body.name?.trim();
   if (!name) {
     return NextResponse.json({ error: "Project name is required" }, { status: 400 });
   }
+
+  // Ensure user row exists
+  await insforge.database
+    .from('users')
+    .upsert(
+      { id: session.user.id, email: session.user.email!, name: session.user.name ?? null, image: session.user.image ?? null },
+      { onConflict: 'id' }
+    );
 
   const { data: project, error } = await insforge.database
     .from('projects')
@@ -39,6 +55,11 @@ export async function POST(req: NextRequest) {
       name,
       description: body.description?.trim() || null,
       userId: session.user.id,
+      repoUrl: body.repoUrl ?? null,
+      repoFullName: body.repoFullName ?? null,
+      cloneUrl: body.cloneUrl ?? null,
+      defaultBranch: body.defaultBranch ?? 'main',
+      status: body.repoUrl ? 'pending' : 'draft',
     })
     .select()
     .single();

--- a/apps/web/app/api/projects/route.ts
+++ b/apps/web/app/api/projects/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { insforge } from "@/lib/insforge";
+import { logActivity } from "@/lib/activity";
 
 export async function GET() {
   const session = await getServerSession(authOptions);

--- a/apps/web/app/api/user/api-keys/[id]/route.ts
+++ b/apps/web/app/api/user/api-keys/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+// PATCH — rename a key
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await req.json() as { name?: string };
+  const name = body.name?.trim();
+  if (!name) return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+
+  const { data: key, error } = await insforge.database
+    .from('api_keys')
+    .update({ name })
+    .eq('id', id)
+    .eq('userId', session.user.id)
+    .select('id, name, prefix, createdAt')
+    .single();
+
+  if (error || !key) {
+    return NextResponse.json({ error: 'Key not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ key });
+}
+
+// DELETE — revoke a key
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const { error } = await insforge.database
+    .from('api_keys')
+    .delete()
+    .eq('id', id)
+    .eq('userId', session.user.id);
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to revoke key' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/user/api-keys/route.ts
+++ b/apps/web/app/api/user/api-keys/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+import { randomBytes } from 'crypto';
+
+// GET — list the user's API keys (token value is never returned after creation)
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: keys } = await insforge.database
+    .from('api_keys')
+    .select('id, name, prefix, createdAt, lastUsedAt')
+    .eq('userId', session.user.id)
+    .order('createdAt', { ascending: false });
+
+  return NextResponse.json({ keys: keys ?? [] });
+}
+
+// POST — generate a new API key
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Limit to 5 keys per user
+  const { data: existing } = await insforge.database
+    .from('api_keys')
+    .select('id')
+    .eq('userId', session.user.id);
+
+  if ((existing?.length ?? 0) >= 5) {
+    return NextResponse.json(
+      { error: 'Maximum of 5 API keys allowed. Delete one to create a new key.' },
+      { status: 400 }
+    );
+  }
+
+  const rawToken = `pdfy_${randomBytes(32).toString('hex')}`;
+  const prefix = rawToken.slice(0, 12); // e.g. "pdfy_a1b2c3"
+
+  const { data: key, error } = await insforge.database
+    .from('api_keys')
+    .insert({
+      userId: session.user.id,
+      name: `Key ${(existing?.length ?? 0) + 1}`,
+      token: rawToken,
+      prefix,
+    })
+    .select('id, name, prefix, createdAt')
+    .single();
+
+  if (error || !key) {
+    return NextResponse.json({ error: 'Failed to create API key' }, { status: 500 });
+  }
+
+  // Return the full token ONCE — it will never be shown again
+  return NextResponse.json({ key: { ...key, token: rawToken } }, { status: 201 });
+}

--- a/apps/web/app/api/user/delete/route.ts
+++ b/apps/web/app/api/user/delete/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { insforge } from '@/lib/insforge';
+
+export async function DELETE() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  // Delete in dependency order
+  await insforge.database.from('api_keys').delete().eq('userId', userId);
+  await insforge.database.from('activity_events').delete().eq('userId', userId);
+  await insforge.database.from('github_connections').delete().eq('userId', userId);
+  await insforge.database.from('projects').delete().eq('userId', userId);
+
+  const { error } = await insforge.database
+    .from('users')
+    .delete()
+    .eq('id', userId);
+
+  if (error) {
+    console.error('[delete account] error:', error);
+    return NextResponse.json({ error: 'Failed to delete account' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/components/auth/reset-password-form.tsx
+++ b/apps/web/components/auth/reset-password-form.tsx
@@ -10,14 +10,21 @@ import { resetPasswordSchema, type ResetPasswordInput } from '@/lib/validations'
 export function ResetPasswordForm() {
   const router = useRouter();
   const params = useSearchParams();
-  const token = params.get('token');
+  const tokenFromUrl = params.get('token');
+  const [manualCode, setManualCode] = useState('');
   const [error, setError] = useState('');
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<ResetPasswordInput>({
     resolver: zodResolver(resetPasswordSchema),
   });
 
+  const token = tokenFromUrl ?? manualCode.trim();
+
   async function onSubmit(data: ResetPasswordInput) {
     setError('');
+    if (!token) {
+      setError('Please enter the reset code from your email.');
+      return;
+    }
     const res = await fetch('/api/auth/reset-password', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -33,23 +40,27 @@ export function ResetPasswordForm() {
 
   const inputStyle = { background: '#1b1e3d', border: '1px solid #323779', color: '#e3f4f8' };
 
-  if (!token) {
-    return (
-      <div className="glass-card rounded-3xl p-8 text-center">
-        <div className="text-4xl mb-4">⚠️</div>
-        <h2 className="text-xl font-bold mb-2" style={{ color: '#e3f4f8' }}>Invalid link</h2>
-        <p className="text-sm mb-6" style={{ color: '#8589b2' }}>This reset link is missing a token.</p>
-        <Link href="/forgot-password" className="text-sm font-medium" style={{ color: '#00d7ff' }}>Request a new link</Link>
-      </div>
-    );
-  }
-
   return (
     <div className="glass-card rounded-3xl p-8">
       <h2 className="text-xl font-bold mb-1" style={{ color: '#e3f4f8' }}>Set new password</h2>
-      <p className="text-sm mb-6" style={{ color: '#8589b2' }}>Choose a strong password for your account</p>
+      <p className="text-sm mb-6" style={{ color: '#8589b2' }}>Enter the code from your email and choose a new password</p>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        {!tokenFromUrl && (
+          <div>
+            <label className="block text-xs font-medium mb-1.5" style={{ color: '#8589b2' }}>Reset code</label>
+            <input
+              type="text"
+              value={manualCode}
+              onChange={e => setManualCode(e.target.value)}
+              className="w-full px-4 py-3 rounded-xl text-sm outline-none transition-all tracking-widest text-center"
+              style={inputStyle}
+              onFocus={e => (e.target.style.borderColor = '#575efe')}
+              onBlur={e => (e.target.style.borderColor = '#323779')}
+              placeholder="Paste code from email"
+            />
+          </div>
+        )}
         <div>
           <label className="block text-xs font-medium mb-1.5" style={{ color: '#8589b2' }}>New password</label>
           <input
@@ -85,6 +96,9 @@ export function ResetPasswordForm() {
         >
           {isSubmitting ? 'Saving...' : 'Set password'}
         </button>
+        <p className="text-center text-xs" style={{ color: '#8589b2' }}>
+          <Link href="/forgot-password" style={{ color: '#00d7ff' }}>Request a new code</Link>
+        </p>
       </form>
     </div>
   );

--- a/apps/web/components/dashboard/repo-import-dialog.tsx
+++ b/apps/web/components/dashboard/repo-import-dialog.tsx
@@ -30,6 +30,7 @@ type Repo = {
 type Props = {
   open: boolean;
   onOpenChange: (v: boolean) => void;
+  onImported?: () => void;
 };
 
 const LANGUAGE_COLORS: Record<string, string> = {
@@ -42,7 +43,7 @@ const LANGUAGE_COLORS: Record<string, string> = {
   CSS: '#563d7c',
 };
 
-export function RepoImportDialog({ open, onOpenChange }: Props) {
+export function RepoImportDialog({ open, onOpenChange, onImported }: Props) {
   const router = useRouter();
   const [step, setStep] = useState<'loading' | 'connect' | 'pick' | 'manual' | 'creating'>('loading');
   const [repos, setRepos] = useState<Repo[]>([]);
@@ -97,6 +98,7 @@ export function RepoImportDialog({ open, onOpenChange }: Props) {
     }
 
     onOpenChange(false);
+    onImported?.();
     router.push(`/dashboard/projects/${data.project.id}`);
   }
 

--- a/apps/web/components/dashboard/repo-import-dialog.tsx
+++ b/apps/web/components/dashboard/repo-import-dialog.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+type Repo = {
+  id: number;
+  name: string;
+  fullName: string;
+  description: string | null;
+  url: string;
+  cloneUrl: string;
+  language: string | null;
+  stars: number;
+  pushedAt: string;
+  private: boolean;
+  defaultBranch: string;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+};
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  Go: '#00ADD8',
+  Rust: '#dea584',
+  Ruby: '#701516',
+  CSS: '#563d7c',
+};
+
+export function RepoImportDialog({ open, onOpenChange }: Props) {
+  const router = useRouter();
+  const [step, setStep] = useState<'loading' | 'connect' | 'pick' | 'manual' | 'creating'>('loading');
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [search, setSearch] = useState('');
+  const [manualUrl, setManualUrl] = useState('');
+  const [manualName, setManualName] = useState('');
+  const [error, setError] = useState('');
+  const [githubLogin, setGithubLogin] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setStep('loading');
+    setSearch('');
+    setError('');
+
+    fetch('/api/github/repos')
+      .then(r => r.json())
+      .then((data: { connected: boolean; login?: string; repos?: Repo[] }) => {
+        if (!data.connected) {
+          setStep('connect');
+        } else {
+          setRepos(data.repos ?? []);
+          setGithubLogin(data.login ?? '');
+          setStep('pick');
+        }
+      })
+      .catch(() => setStep('connect'));
+  }, [open]);
+
+  async function createProject(payload: {
+    name: string;
+    repoUrl: string;
+    repoFullName: string;
+    cloneUrl: string;
+    defaultBranch: string;
+  }) {
+    setStep('creating');
+    setError('');
+
+    const res = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await res.json() as { project?: { id: string }; error?: string };
+
+    if (!res.ok || !data.project) {
+      setError(data.error ?? 'Failed to create project');
+      setStep('pick');
+      return;
+    }
+
+    onOpenChange(false);
+    router.push(`/dashboard/projects/${data.project.id}`);
+  }
+
+  function handleRepoSelect(repo: Repo) {
+    void createProject({
+      name: repo.name,
+      repoUrl: repo.url,
+      repoFullName: repo.fullName,
+      cloneUrl: repo.cloneUrl,
+      defaultBranch: repo.defaultBranch,
+    });
+  }
+
+  async function handleManualSubmit() {
+    if (!manualUrl.trim()) { setError('Paste a GitHub repo URL'); return; }
+    const match = manualUrl.trim().match(/github\.com\/([^/]+\/[^/]+)/);
+    if (!match) { setError('Must be a valid GitHub URL (github.com/owner/repo)'); return; }
+    const fullName = match[1].replace(/\.git$/, '');
+    const name = manualName.trim() || fullName.split('/')[1] || fullName;
+    await createProject({
+      name,
+      repoUrl: `https://github.com/${fullName}`,
+      repoFullName: fullName,
+      cloneUrl: `https://github.com/${fullName}.git`,
+      defaultBranch: 'main',
+    });
+  }
+
+  const filtered = repos.filter(r =>
+    r.name.toLowerCase().includes(search.toLowerCase()) ||
+    (r.description ?? '').toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Import a repository</DialogTitle>
+          <DialogDescription>
+            {step === 'connect'
+              ? 'Connect your GitHub account to import repos'
+              : step === 'manual'
+              ? 'Paste any public GitHub repository URL'
+              : 'Select a repository to analyze and inject'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* LOADING */}
+        {step === 'loading' && (
+          <div className="flex items-center justify-center py-16">
+            <div className="w-6 h-6 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+
+        {/* CONNECT GITHUB */}
+        {step === 'connect' && (
+          <div className="flex flex-col items-center gap-4 py-10">
+            <div className="w-16 h-16 rounded-2xl bg-gray-900 flex items-center justify-center">
+              <svg className="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+            </div>
+            <div className="text-center">
+              <p className="font-semibold text-gray-900 mb-1">Connect GitHub to import repos</p>
+              <p className="text-sm text-gray-500">Prodify needs repo access to analyze and inject infrastructure</p>
+            </div>
+            <Button
+              className="bg-gray-900 hover:bg-gray-800 text-white"
+              onClick={() => void signIn('github', { callbackUrl: '/dashboard' })}
+            >
+              Connect GitHub
+            </Button>
+            <button
+              onClick={() => setStep('manual')}
+              className="text-sm text-violet-600 hover:underline"
+            >
+              Or paste a public repo URL instead
+            </button>
+          </div>
+        )}
+
+        {/* REPO PICKER */}
+        {step === 'pick' && (
+          <>
+            <div className="flex gap-2">
+              <Input
+                placeholder="Search repos..."
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                autoFocus
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setStep('manual')}
+                className="shrink-0 text-xs"
+              >
+                Paste URL
+              </Button>
+            </div>
+            {githubLogin && (
+              <p className="text-xs text-gray-400">Showing repos from <span className="font-medium text-gray-600">@{githubLogin}</span></p>
+            )}
+            <div className="overflow-y-auto flex-1 space-y-1 pr-1">
+              {filtered.length === 0 && (
+                <p className="text-sm text-gray-400 text-center py-8">No repos match your search</p>
+              )}
+              {filtered.map(repo => (
+                <button
+                  key={repo.id}
+                  onClick={() => handleRepoSelect(repo)}
+                  className="w-full text-left p-3 rounded-xl border border-transparent hover:border-violet-200 hover:bg-violet-50 transition-all group"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="font-medium text-sm text-gray-900 truncate">{repo.name}</span>
+                      {repo.private && (
+                        <span className="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded shrink-0">Private</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0 text-xs text-gray-400">
+                      {repo.language && (
+                        <span className="flex items-center gap-1">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ background: LANGUAGE_COLORS[repo.language] ?? '#888' }}
+                          />
+                          {repo.language}
+                        </span>
+                      )}
+                      {repo.stars > 0 && <span>★ {repo.stars}</span>}
+                    </div>
+                  </div>
+                  {repo.description && (
+                    <p className="text-xs text-gray-500 mt-0.5 truncate">{repo.description}</p>
+                  )}
+                </button>
+              ))}
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
+          </>
+        )}
+
+        {/* MANUAL URL */}
+        {step === 'manual' && (
+          <div className="space-y-4 py-2">
+            <div>
+              <label className="text-xs font-medium text-gray-600 mb-1 block">GitHub repo URL</label>
+              <Input
+                placeholder="https://github.com/owner/repo"
+                value={manualUrl}
+                onChange={e => setManualUrl(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-600 mb-1 block">Project name (optional)</label>
+              <Input
+                placeholder="Leave blank to use repo name"
+                value={manualName}
+                onChange={e => setManualName(e.target.value)}
+              />
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setStep(repos.length > 0 ? 'pick' : 'connect')}>
+                Back
+              </Button>
+              <Button
+                className="bg-violet-600 hover:bg-violet-700 text-white flex-1"
+                onClick={() => void handleManualSubmit()}
+              >
+                Import repo
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* CREATING */}
+        {step === 'creating' && (
+          <div className="flex flex-col items-center gap-3 py-10">
+            <div className="w-6 h-6 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-gray-500">Creating project...</p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/db/migrations/002_activity_events_and_api_keys.sql
+++ b/apps/web/db/migrations/002_activity_events_and_api_keys.sql
@@ -1,0 +1,37 @@
+-- Migration 002: activity_events + api_keys tables
+-- Run this in your InsForge dashboard → SQL Editor
+
+-- Activity events (used by the dashboard activity feed)
+CREATE TABLE IF NOT EXISTS activity_events (
+  id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "userId"    TEXT NOT NULL,
+  "projectId" TEXT,
+  "projectName" TEXT,
+  type        TEXT NOT NULL,
+  message     TEXT NOT NULL,
+  metadata    JSONB,
+  "createdAt" TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS activity_events_user_idx
+  ON activity_events ("userId");
+
+CREATE INDEX IF NOT EXISTS activity_events_project_idx
+  ON activity_events ("projectId");
+
+-- API keys (used by Settings → API Keys tab)
+CREATE TABLE IF NOT EXISTS api_keys (
+  id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "userId"     TEXT NOT NULL,
+  name         TEXT NOT NULL DEFAULT 'My Key',
+  token        TEXT NOT NULL UNIQUE,
+  prefix       TEXT NOT NULL,
+  "lastUsedAt" TIMESTAMPTZ,
+  "createdAt"  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS api_keys_user_idx
+  ON api_keys ("userId");
+
+CREATE INDEX IF NOT EXISTS api_keys_token_idx
+  ON api_keys (token);

--- a/apps/web/lib/activity.ts
+++ b/apps/web/lib/activity.ts
@@ -1,0 +1,29 @@
+import { insforge } from './insforge';
+
+export type ActivityType =
+  | 'project_created'
+  | 'analysis_started'
+  | 'analysis_completed'
+  | 'analysis_failed'
+  | 'injection_started'
+  | 'injection_completed'
+  | 'injection_failed'
+  | 'pr_opened';
+
+export async function logActivity(params: {
+  userId: string;
+  projectId?: string;
+  projectName?: string;
+  type: ActivityType;
+  message: string;
+  metadata?: Record<string, unknown>;
+}) {
+  await insforge.database.from('activity_events').insert({
+    userId: params.userId,
+    projectId: params.projectId ?? null,
+    projectName: params.projectName ?? null,
+    type: params.type,
+    message: params.message,
+    metadata: params.metadata ?? null,
+  });
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -4,7 +4,6 @@ import GitHubProvider from 'next-auth/providers/github';
 import { insforge } from './insforge';
 
 export const authOptions: NextAuthOptions = {
-  // No PrismaAdapter — sessions are JWT-only; user records live in InsForge
   session: { strategy: 'jwt' },
   pages: {
     signIn: '/login',
@@ -14,6 +13,9 @@ export const authOptions: NextAuthOptions = {
     GitHubProvider({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+      authorization: {
+        params: { scope: 'read:user user:email repo' },
+      },
     }),
     CredentialsProvider({
       name: 'credentials',
@@ -31,30 +33,68 @@ export const authOptions: NextAuthOptions = {
 
         if (error || !data?.user) return null;
 
-        // Store the InsForge access token in the token so we can use it for
-        // authenticated InsForge SDK calls later (stored in JWT, not exposed to client)
         return {
           id: data.user.id,
           email: data.user.email,
           name: data.user.profile?.name ?? null,
           image: data.user.profile?.avatar_url ?? null,
-          // Carry the InsForge access token inside the Next-Auth JWT
           accessToken: data.accessToken,
         };
       },
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, account }) {
       if (user) {
         token.id = user.id;
         token.accessToken = (user as { accessToken?: string }).accessToken;
+      }
+      // Capture GitHub OAuth access token for repo API calls
+      if (account?.provider === 'github' && account.access_token) {
+        token.githubAccessToken = account.access_token;
+        token.githubLogin = (account as { login?: string }).login;
       }
       return token;
     },
     async session({ session, token }) {
       if (token?.id) session.user.id = token.id as string;
+      if (token?.githubAccessToken) {
+        (session as { githubAccessToken?: string }).githubAccessToken = token.githubAccessToken as string;
+      }
       return session;
+    },
+    async signIn({ user, account, profile }) {
+      if (account?.provider === 'github') {
+        // Upsert user into InsForge users table
+        await insforge.database
+          .from('users')
+          .upsert(
+            {
+              id: user.id,
+              email: user.email!,
+              name: user.name ?? null,
+              image: user.image ?? null,
+            },
+            { onConflict: 'email' }
+          );
+
+        // Store GitHub connection
+        const githubProfile = profile as { login?: string; avatar_url?: string } | undefined;
+        if (account.access_token && githubProfile?.login) {
+          await insforge.database
+            .from('github_connections')
+            .upsert(
+              {
+                userId: user.id,
+                github_login: githubProfile.login,
+                github_avatar: githubProfile.avatar_url ?? null,
+                access_token: account.access_token,
+              },
+              { onConflict: 'userId' }
+            );
+        }
+      }
+      return true;
     },
   },
 };

--- a/apps/web/lib/insforge.ts
+++ b/apps/web/lib/insforge.ts
@@ -7,9 +7,9 @@ const globalForInsforge = globalThis as unknown as {
 
 function makeInsforgeClient() {
   return createClient({
-    baseUrl: process.env.INSFORGE_URL!,
-    anonKey: process.env.INSFORGE_ANON_KEY,
-    isServerMode: true, // we're always server-side in Next.js API routes
+    baseUrl: (process.env.INSFORGE_URL ?? process.env.NEXT_PUBLIC_INSFORGE_URL)!,
+    anonKey: process.env.INSFORGE_ANON_KEY ?? process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY,
+    isServerMode: true,
   });
 }
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const config: NextConfig = {
+  transpilePackages: ['@prodify/injector'],
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'avatars.githubusercontent.com' },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@insforge/sdk": "^1.0.0",
     "@base-ui/react": "^1.4.1",
     "@hookform/resolvers": "^5.2.2",
+    "@insforge/sdk": "^1.0.0",
+    "@prodify/injector": "^0.1.0",
+    "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
@@ -24,6 +26,7 @@
     "react-hook-form": "^7.73.1",
     "resend": "^6.12.2",
     "shadcn": "^4.4.0",
+    "simple-git": "^3.36.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@prodify/injector/*": ["../../packages/injector/*"]
     }
   },
   "include": [

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,9 +1,19 @@
-import { DefaultSession } from 'next-auth';
+import { DefaultSession, DefaultJWT } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
     user: {
       id: string;
     } & DefaultSession['user'];
+    githubAccessToken?: string;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT extends DefaultJWT {
+    id?: string;
+    accessToken?: string;
+    githubAccessToken?: string;
+    githubLogin?: string;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "@prisma/client": "^5.22.0"
+        "@prisma/client": "^5.22.0",
+        "supermemory": "^4.21.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -34,6 +35,7 @@
         "react-hook-form": "^7.73.1",
         "resend": "^6.12.2",
         "shadcn": "^4.4.0",
+        "simple-git": "^3.36.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6"
@@ -3340,6 +3342,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -3752,6 +3769,21 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -8763,6 +8795,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14133,6 +14166,23 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14551,6 +14601,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/supermemory": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/supermemory/-/supermemory-4.21.1.tgz",
+      "integrity": "sha512-KayOHtD94g7O+yN2qxaHEO5UIXtDl+duaKuhW7gvaraVtP1RHxFn80Pb5s5rKmqIvC+ruaARRlgMw7s/y+6LGQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "supermemory": "bin/cli"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@base-ui/react": "^1.4.1",
         "@hookform/resolvers": "^5.2.2",
         "@insforge/sdk": "^1.0.0",
+        "@prodify/injector": "^0.1.0",
+        "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -3756,6 +3758,39 @@
     "node_modules/@prodify/injector": {
       "resolved": "packages/injector",
       "link": true
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@prisma/client": "^5.22.0"
+    "@prisma/client": "^5.22.0",
+    "supermemory": "^4.21.1"
   }
 }

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -10,7 +10,7 @@ const bedrock = new BedrockRuntimeClient({
   } : undefined,
 });
 
-const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'anthropic.claude-3-5-sonnet-20240620-v1:0';
+const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'anthropic.claude-3-5-sonnet-20241022-v2:0';
 
 export interface InjectionOpportunity {
   layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -10,7 +10,7 @@ const bedrock = new BedrockRuntimeClient({
   } : undefined,
 });
 
-const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-3-5-sonnet-20241022-v2:0';
+const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-3-5-haiku-20241022-v1:0';
 
 export interface InjectionOpportunity {
   layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -10,7 +10,7 @@ const bedrock = new BedrockRuntimeClient({
   } : undefined,
 });
 
-const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-3-5-haiku-20241022-v1:0';
+const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
 
 export interface InjectionOpportunity {
   layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';
@@ -84,9 +84,16 @@ export async function analyzeRepository(targetDir: string): Promise<AnalysisRepo
     readFileSafe(path.join(targetDir, 'tsconfig.json'), 300),
   ]);
 
-  const prompt = `You are an expert Next.js developer analyzing a GitHub repository to inject production-ready SaaS infrastructure (auth, payments, database).
+  const prompt = `You are a senior engineer performing a precise technical audit of a GitHub repository. Your job is to detect what infrastructure already EXISTS in the codebase and what is MISSING.
 
-Analyze this project thoroughly and return a detailed JSON report.
+CRITICAL RULES:
+- Only mark something as present (hasAuth, hasPayments, hasDatabase) if you find CONCRETE EVIDENCE in the files below
+- Evidence for payments: stripe, lemon-squeezy, paddle, chargebee in package.json dependencies OR files named checkout/billing/webhook/subscription
+- Evidence for auth: next-auth, clerk, auth0, supabase auth, firebase auth in package.json OR files named [...nextauth], auth.ts, middleware.ts with auth logic
+- Evidence for database: prisma, drizzle, supabase, mongoose, pg, mysql2 in package.json OR schema files, migration files
+- Evidence for CI: .github/workflows/ directory in the file tree
+- If you don't see it in the data below, it does NOT exist — do not infer or assume
+- The summary must be factual and specific, not marketing language
 
 === package.json ===
 ${packageJson}
@@ -103,7 +110,7 @@ ${nextConfig}
 === tsconfig ===
 ${tsConfig}
 
-Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no explanation):
+Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no explanation, no code fences):
 
 {
   "detectedStack": {
@@ -122,20 +129,20 @@ Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no
     {
       "layer": "auth" | "payments" | "database" | "ci" | "env",
       "canInject": boolean,
-      "currentState": "short description of current state",
-      "proposed": "short description of what Prodify will inject",
+      "currentState": "exact description of what exists or 'None detected'",
+      "proposed": "exactly what Prodify will inject",
       "filesToCreate": ["list", "of", "file", "paths"],
       "effort": "low" | "medium" | "high"
     }
   ],
   "conflicts": [
     {
-      "description": "what conflicts",
+      "description": "specific conflict based on evidence found",
       "severity": "warning" | "blocker",
-      "resolution": "how to resolve"
+      "resolution": "concrete resolution step"
     }
   ],
-  "summary": "2-3 sentence human-readable summary of the project and what Prodify will do"
+  "summary": "2-3 sentences: what the app does, what infrastructure exists, what is missing. Be factual and specific."
 }`;
 
   const payload = {

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -19,30 +19,48 @@ export interface InjectionOpportunity {
   proposed: string;
   filesToCreate: string[];
   effort: 'low' | 'medium' | 'high';
+  // Extended detail fields
+  gaps: string[];           // specific things missing in this layer
+  implementation: string;   // exactly what Prodify will build
+  envVarsNeeded: string[];  // env vars required for this layer
 }
 
 export interface ConflictWarning {
   description: string;
   severity: 'warning' | 'blocker';
   resolution: string;
+  affectedFiles: string[];
 }
 
 export interface AnalysisReport {
   detectedStack: {
     framework: string;
+    frameworkVersion: string;
     language: 'typescript' | 'javascript' | 'unknown';
+    nodeVersion: string | null;
     hasAuth: boolean;
     authProvider: string | null;
+    authDetails: string | null;       // e.g. "next-auth v4 with GitHub + credentials providers"
     hasPayments: boolean;
     paymentsProvider: string | null;
+    paymentsDetails: string | null;   // e.g. "Stripe SDK found but no webhook handler"
     hasDatabase: boolean;
     dbProvider: string | null;
+    dbDetails: string | null;         // e.g. "Prisma with PostgreSQL, 3 models detected"
     hasCI: boolean;
+    ciDetails: string | null;
+    otherDependencies: string[];      // notable libs: tailwind, shadcn, zod, react-query etc
   };
   pattern: 'crud' | 'dashboard' | 'landing' | 'ai-app' | 'ecommerce' | 'generic';
+  appDescription: string;             // what the app actually does
   injectionOpportunities: InjectionOpportunity[];
   conflicts: ConflictWarning[];
   summary: string;
+  monetizationReadiness: {
+    score: number;                    // 0-100
+    blockers: string[];               // things that MUST be done before monetizing
+    quickWins: string[];              // things Prodify can inject immediately
+  };
 }
 
 // Legacy type kept for backwards compat
@@ -59,95 +77,147 @@ async function readFileSafe(p: string, maxChars = 2000): Promise<string> {
   try { return (await fs.readFile(p, 'utf-8')).slice(0, maxChars); } catch { return ''; }
 }
 
-async function buildFileTree(dir: string, maxFiles = 80): Promise<string> {
+async function buildFileTree(dir: string, maxFiles = 120): Promise<string> {
   try {
     const files = await fs.readdir(dir, { recursive: true }) as string[];
     return files
-      .filter(f => !f.includes('node_modules') && !f.includes('.next') && !f.includes('.git'))
+      .filter(f =>
+        !f.includes('node_modules') &&
+        !f.includes('.next') &&
+        !f.includes('.git') &&
+        !f.includes('dist') &&
+        !f.includes('.turbo')
+      )
       .slice(0, maxFiles)
       .join('\n');
   } catch { return ''; }
 }
 
+// Read key source files to give the AI real code context
+async function readKeySourceFiles(dir: string): Promise<string> {
+  const candidates = [
+    // Auth
+    'lib/auth.ts', 'lib/auth.js', 'app/api/auth/[...nextauth]/route.ts',
+    'pages/api/auth/[...nextauth].ts', 'middleware.ts', 'middleware.js',
+    // Payments
+    'lib/stripe.ts', 'lib/stripe.js', 'lib/payments.ts',
+    'app/api/webhooks/stripe/route.ts', 'app/api/checkout/route.ts',
+    'pages/api/webhooks/stripe.ts', 'pages/api/checkout.ts',
+    // Database
+    'lib/db.ts', 'lib/db.js', 'lib/prisma.ts', 'lib/supabase.ts',
+    'prisma/schema.prisma', 'drizzle.config.ts', 'db/schema.ts',
+    // Config
+    'next.config.ts', 'next.config.js', 'next.config.mjs',
+    '.env.example', '.env.local.example',
+  ];
+
+  const results: string[] = [];
+  for (const rel of candidates) {
+    const content = await readFileSafe(path.join(dir, rel), 1500);
+    if (content) {
+      results.push(`\n=== ${rel} ===\n${content}`);
+    }
+  }
+  return results.join('\n');
+}
+
 export async function analyzeRepository(targetDir: string): Promise<AnalysisReport> {
-  const [packageJson, packageLock, tree, envExample] = await Promise.all([
-    readFileSafe(path.join(targetDir, 'package.json'), 3000),
-    readFileSafe(path.join(targetDir, 'package-lock.json'), 500),
+  const [packageJson, tree, envExample, sourceFiles] = await Promise.all([
+    readFileSafe(path.join(targetDir, 'package.json'), 4000),
     buildFileTree(targetDir),
-    readFileSafe(path.join(targetDir, '.env.example'), 1000),
+    readFileSafe(path.join(targetDir, '.env.example'), 1500),
+    readKeySourceFiles(targetDir),
   ]);
 
-  // Also peek at next.config and tsconfig to understand the stack
-  const [nextConfig, tsConfig] = await Promise.all([
-    readFileSafe(path.join(targetDir, 'next.config.ts'), 500)
-      .then(c => c || readFileSafe(path.join(targetDir, 'next.config.js'), 500)),
-    readFileSafe(path.join(targetDir, 'tsconfig.json'), 300),
-  ]);
+  const prompt = `You are a senior full-stack engineer and SaaS monetization expert performing a deep technical audit of a GitHub repository. You are preparing a detailed report for a developer who wants to add production-grade auth, payments, and database infrastructure to their existing app.
 
-  const prompt = `You are a senior engineer performing a precise technical audit of a GitHub repository. Your job is to detect what infrastructure already EXISTS in the codebase and what is MISSING.
-
-CRITICAL RULES:
-- Only mark something as present (hasAuth, hasPayments, hasDatabase) if you find CONCRETE EVIDENCE in the files below
-- Evidence for payments: stripe, lemon-squeezy, paddle, chargebee in package.json dependencies OR files named checkout/billing/webhook/subscription
-- Evidence for auth: next-auth, clerk, auth0, supabase auth, firebase auth in package.json OR files named [...nextauth], auth.ts, middleware.ts with auth logic
-- Evidence for database: prisma, drizzle, supabase, mongoose, pg, mysql2 in package.json OR schema files, migration files
-- Evidence for CI: .github/workflows/ directory in the file tree
-- If you don't see it in the data below, it does NOT exist — do not infer or assume
-- The summary must be factual and specific, not marketing language
+Your analysis must be DEEP, SPECIFIC, and ACTIONABLE — not generic. Reference actual file names, package versions, and code patterns you find. A developer reading this should know EXACTLY what is missing and what needs to be built.
 
 === package.json ===
 ${packageJson}
 
-=== File tree (first 80 files) ===
+=== File tree ===
 ${tree}
 
 === .env.example ===
 ${envExample}
 
-=== next.config ===
-${nextConfig}
+=== Key source files ===
+${sourceFiles}
 
-=== tsconfig ===
-${tsConfig}
+---
 
-Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no explanation, no code fences):
+DETECTION RULES (only mark as present if you find concrete evidence):
+- hasAuth=true: next-auth/clerk/auth0/supabase-auth/firebase in deps OR auth route files found
+- hasPayments=true: stripe/lemon-squeezy/paddle in deps OR checkout/webhook/billing files found  
+- hasDatabase=true: prisma/drizzle/supabase/mongoose/pg in deps OR schema/migration files found
+- hasCI=true: .github/workflows/ appears in file tree
+
+For each injection layer, provide:
+- gaps: specific things that are MISSING (e.g. "No Stripe webhook handler", "No subscription table", "No customer portal route")
+- implementation: detailed description of exactly what will be built (e.g. "Stripe Checkout with price IDs, webhook handler for checkout.session.completed and customer.subscription.*, subscription status stored in DB, customer portal at /api/billing/portal")
+- envVarsNeeded: exact env var names needed (e.g. STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID_MONTHLY)
+
+For monetizationReadiness:
+- score: 0-100 based on how close the app is to being able to charge users
+- blockers: specific technical blockers (e.g. "No user identity system — can't associate payments with users", "No database — can't store subscription status")
+- quickWins: things Prodify can inject in one shot (e.g. "Full Stripe checkout + webhook pipeline", "InsForge subscriptions table with RLS")
+
+Return ONLY valid JSON — no markdown, no code fences, no explanation:
 
 {
   "detectedStack": {
-    "framework": "string (e.g. 'Next.js 14 App Router')",
+    "framework": "string",
+    "frameworkVersion": "string",
     "language": "typescript" | "javascript" | "unknown",
+    "nodeVersion": string | null,
     "hasAuth": boolean,
     "authProvider": string | null,
+    "authDetails": string | null,
     "hasPayments": boolean,
     "paymentsProvider": string | null,
+    "paymentsDetails": string | null,
     "hasDatabase": boolean,
     "dbProvider": string | null,
-    "hasCI": boolean
+    "dbDetails": string | null,
+    "hasCI": boolean,
+    "ciDetails": string | null,
+    "otherDependencies": ["array of notable libs"]
   },
   "pattern": "crud" | "dashboard" | "landing" | "ai-app" | "ecommerce" | "generic",
+  "appDescription": "2-3 sentences describing what this app actually does based on the code",
   "injectionOpportunities": [
     {
       "layer": "auth" | "payments" | "database" | "ci" | "env",
       "canInject": boolean,
-      "currentState": "exact description of what exists or 'None detected'",
-      "proposed": "exactly what Prodify will inject",
-      "filesToCreate": ["list", "of", "file", "paths"],
-      "effort": "low" | "medium" | "high"
+      "currentState": "specific description of what exists, referencing actual files/packages found",
+      "proposed": "specific description of what will be injected",
+      "filesToCreate": ["exact/file/paths/that/will/be/created.ts"],
+      "effort": "low" | "medium" | "high",
+      "gaps": ["specific gap 1", "specific gap 2"],
+      "implementation": "detailed paragraph describing exactly what will be built and how it integrates with the existing code",
+      "envVarsNeeded": ["EXACT_ENV_VAR_NAME_1", "EXACT_ENV_VAR_NAME_2"]
     }
   ],
   "conflicts": [
     {
-      "description": "specific conflict based on evidence found",
+      "description": "specific conflict referencing actual files/packages",
       "severity": "warning" | "blocker",
-      "resolution": "concrete resolution step"
+      "resolution": "concrete step-by-step resolution",
+      "affectedFiles": ["file/that/conflicts.ts"]
     }
   ],
-  "summary": "2-3 sentences: what the app does, what infrastructure exists, what is missing. Be factual and specific."
+  "summary": "3-4 sentences: what the app does, exact infrastructure state, what is missing, monetization gap",
+  "monetizationReadiness": {
+    "score": 0-100,
+    "blockers": ["specific blocker 1", "specific blocker 2"],
+    "quickWins": ["specific quick win 1", "specific quick win 2"]
+  }
 }`;
 
   const payload = {
     anthropic_version: 'bedrock-2023-05-31',
-    max_tokens: 2000,
+    max_tokens: 4000,
     messages: [{ role: 'user', content: prompt }],
   };
 
@@ -168,28 +238,76 @@ Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no
     return JSON.parse(jsonStr) as AnalysisReport;
   } catch (error) {
     console.error('[analyzer] Bedrock error:', error);
-    // Return a sensible fallback so the UI still works
     return {
       detectedStack: {
         framework: 'Next.js',
+        frameworkVersion: 'unknown',
         language: 'typescript',
+        nodeVersion: null,
         hasAuth: false,
         authProvider: null,
+        authDetails: null,
         hasPayments: false,
         paymentsProvider: null,
+        paymentsDetails: null,
         hasDatabase: false,
         dbProvider: null,
+        dbDetails: null,
         hasCI: false,
+        ciDetails: null,
+        otherDependencies: [],
       },
       pattern: 'generic',
+      appDescription: 'Analysis could not be completed. Please try again.',
       injectionOpportunities: [
-        { layer: 'auth', canInject: true, currentState: 'No auth detected', proposed: 'NextAuth.js with InsForge backend', filesToCreate: ['prodify-layer/auth/[...nextauth].ts'], effort: 'low' },
-        { layer: 'payments', canInject: true, currentState: 'No payments detected', proposed: 'Stripe checkout + webhooks', filesToCreate: ['prodify-layer/payments/stripe.ts'], effort: 'low' },
-        { layer: 'database', canInject: true, currentState: 'No database detected', proposed: 'InsForge SQL schema', filesToCreate: ['prodify-layer/db/schema.sql', 'prodify-layer/db/insforge.ts'], effort: 'low' },
-        { layer: 'ci', canInject: true, currentState: 'No CI detected', proposed: 'GitHub Actions — typecheck + test', filesToCreate: ['.github/workflows/ci.yml'], effort: 'low' },
+        {
+          layer: 'auth', canInject: true,
+          currentState: 'No auth detected',
+          proposed: 'NextAuth.js with InsForge backend',
+          filesToCreate: ['prodify-layer/auth/[...nextauth].ts'],
+          effort: 'low',
+          gaps: ['No authentication system'],
+          implementation: 'NextAuth.js with credentials + GitHub OAuth, session management via InsForge',
+          envVarsNeeded: ['NEXTAUTH_SECRET', 'NEXTAUTH_URL'],
+        },
+        {
+          layer: 'payments', canInject: true,
+          currentState: 'No payments detected',
+          proposed: 'Stripe Checkout + webhooks + customer portal',
+          filesToCreate: ['prodify-layer/payments/stripe.ts', 'prodify-layer/app/api/checkout/route.ts', 'prodify-layer/app/api/webhooks/stripe/route.ts'],
+          effort: 'medium',
+          gaps: ['No Stripe integration', 'No subscription management', 'No webhook handler'],
+          implementation: 'Full Stripe Checkout flow with subscription management, webhook handler for lifecycle events, customer portal',
+          envVarsNeeded: ['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'STRIPE_PRICE_ID'],
+        },
+        {
+          layer: 'database', canInject: true,
+          currentState: 'No database detected',
+          proposed: 'InsForge SQL schema with users, subscriptions tables',
+          filesToCreate: ['prodify-layer/db/schema.sql', 'prodify-layer/db/insforge.ts'],
+          effort: 'low',
+          gaps: ['No database schema', 'No user table', 'No subscription tracking'],
+          implementation: 'InsForge PostgreSQL schema with users, subscriptions, and webhook_events tables',
+          envVarsNeeded: ['INSFORGE_URL', 'INSFORGE_ANON_KEY'],
+        },
+        {
+          layer: 'ci', canInject: true,
+          currentState: 'No CI detected',
+          proposed: 'GitHub Actions — typecheck + test on push/PR',
+          filesToCreate: ['.github/workflows/ci.yml'],
+          effort: 'low',
+          gaps: ['No automated testing pipeline'],
+          implementation: 'GitHub Actions workflow running tsc --noEmit and npm test on every push and PR',
+          envVarsNeeded: [],
+        },
       ],
       conflicts: [],
       summary: 'Analysis could not be completed automatically. All standard injection opportunities are available.',
+      monetizationReadiness: {
+        score: 0,
+        blockers: ['Analysis failed — please retry'],
+        quickWins: [],
+      },
     };
   }
 }

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -2,14 +2,50 @@ import fs from 'fs-extra';
 import path from 'path';
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 
-// Initialize Bedrock client
-// Note: Requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION
 const bedrock = new BedrockRuntimeClient({
   region: process.env.AWS_REGION || 'us-east-1',
+  credentials: process.env.AWS_ACCESS_KEY_ID ? {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  } : undefined,
 });
 
 const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'anthropic.claude-3-5-sonnet-20240620-v1:0';
 
+export interface InjectionOpportunity {
+  layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';
+  canInject: boolean;
+  currentState: string;
+  proposed: string;
+  filesToCreate: string[];
+  effort: 'low' | 'medium' | 'high';
+}
+
+export interface ConflictWarning {
+  description: string;
+  severity: 'warning' | 'blocker';
+  resolution: string;
+}
+
+export interface AnalysisReport {
+  detectedStack: {
+    framework: string;
+    language: 'typescript' | 'javascript' | 'unknown';
+    hasAuth: boolean;
+    authProvider: string | null;
+    hasPayments: boolean;
+    paymentsProvider: string | null;
+    hasDatabase: boolean;
+    dbProvider: string | null;
+    hasCI: boolean;
+  };
+  pattern: 'crud' | 'dashboard' | 'landing' | 'ai-app' | 'ecommerce' | 'generic';
+  injectionOpportunities: InjectionOpportunity[];
+  conflicts: ConflictWarning[];
+  summary: string;
+}
+
+// Legacy type kept for backwards compat
 export interface RetrofitPlan {
   pattern: 'crud' | 'dashboard' | 'generic';
   modifications: Array<{
@@ -19,59 +55,93 @@ export interface RetrofitPlan {
   }>;
 }
 
-export async function analyzeRepository(targetDir: string): Promise<RetrofitPlan> {
-  const packageJsonPath = path.join(targetDir, 'package.json');
-  const appDirPath = path.join(targetDir, 'apps/web/app'); 
-  
-  let packageJson = '';
+async function readFileSafe(p: string, maxChars = 2000): Promise<string> {
+  try { return (await fs.readFile(p, 'utf-8')).slice(0, maxChars); } catch { return ''; }
+}
+
+async function buildFileTree(dir: string, maxFiles = 80): Promise<string> {
   try {
-    packageJson = await fs.readFile(packageJsonPath, 'utf-8');
-  } catch (e) {
-    console.warn('Could not read package.json');
-  }
+    const files = await fs.readdir(dir, { recursive: true }) as string[];
+    return files
+      .filter(f => !f.includes('node_modules') && !f.includes('.next') && !f.includes('.git'))
+      .slice(0, maxFiles)
+      .join('\n');
+  } catch { return ''; }
+}
 
-  let tree = '';
-  try {
-    if (await fs.pathExists(appDirPath)) {
-      const files = await fs.readdir(appDirPath, { recursive: true });
-      tree = files.slice(0, 50).join('\n'); 
-    }
-  } catch (e) {
-    console.warn('Could not read app directory');
-  }
+export async function analyzeRepository(targetDir: string): Promise<AnalysisReport> {
+  const [packageJson, packageLock, tree, envExample] = await Promise.all([
+    readFileSafe(path.join(targetDir, 'package.json'), 3000),
+    readFileSafe(path.join(targetDir, 'package-lock.json'), 500),
+    buildFileTree(targetDir),
+    readFileSafe(path.join(targetDir, '.env.example'), 1000),
+  ]);
 
-  const prompt = `
-You are an expert Next.js developer analyzing a codebase to retrofit it with SaaS infrastructure (auth, payments, DB).
-Analyze the following project structure and package.json to generate a Retrofit Plan.
+  // Also peek at next.config and tsconfig to understand the stack
+  const [nextConfig, tsConfig] = await Promise.all([
+    readFileSafe(path.join(targetDir, 'next.config.ts'), 500)
+      .then(c => c || readFileSafe(path.join(targetDir, 'next.config.js'), 500)),
+    readFileSafe(path.join(targetDir, 'tsconfig.json'), 300),
+  ]);
 
-Project package.json:
-${packageJson.slice(0, 1000)}
+  const prompt = `You are an expert Next.js developer analyzing a GitHub repository to inject production-ready SaaS infrastructure (auth, payments, database).
 
-App Directory Structure:
+Analyze this project thoroughly and return a detailed JSON report.
+
+=== package.json ===
+${packageJson}
+
+=== File tree (first 80 files) ===
 ${tree}
 
-Output ONLY valid JSON matching this TypeScript interface:
+=== .env.example ===
+${envExample}
+
+=== next.config ===
+${nextConfig}
+
+=== tsconfig ===
+${tsConfig}
+
+Return ONLY valid JSON matching this exact TypeScript interface (no markdown, no explanation):
+
 {
-  "pattern": "crud" | "dashboard" | "generic",
-  "modifications": [
+  "detectedStack": {
+    "framework": "string (e.g. 'Next.js 14 App Router')",
+    "language": "typescript" | "javascript" | "unknown",
+    "hasAuth": boolean,
+    "authProvider": string | null,
+    "hasPayments": boolean,
+    "paymentsProvider": string | null,
+    "hasDatabase": boolean,
+    "dbProvider": string | null,
+    "hasCI": boolean
+  },
+  "pattern": "crud" | "dashboard" | "landing" | "ai-app" | "ecommerce" | "generic",
+  "injectionOpportunities": [
     {
-      "file": "path/to/file",
-      "action": "inject_auth" | "inject_stripe" | "inject_db",
-      "description": "What needs to be done"
+      "layer": "auth" | "payments" | "database" | "ci" | "env",
+      "canInject": boolean,
+      "currentState": "short description of current state",
+      "proposed": "short description of what Prodify will inject",
+      "filesToCreate": ["list", "of", "file", "paths"],
+      "effort": "low" | "medium" | "high"
     }
-  ]
-}
-`;
+  ],
+  "conflicts": [
+    {
+      "description": "what conflicts",
+      "severity": "warning" | "blocker",
+      "resolution": "how to resolve"
+    }
+  ],
+  "summary": "2-3 sentence human-readable summary of the project and what Prodify will do"
+}`;
 
   const payload = {
-    anthropic_version: "bedrock-2023-05-31",
-    max_tokens: 1000,
-    messages: [
-      {
-        role: "user",
-        content: prompt
-      }
-    ]
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 2000,
+    messages: [{ role: 'user', content: prompt }],
   };
 
   try {
@@ -83,20 +153,36 @@ Output ONLY valid JSON matching this TypeScript interface:
     });
 
     const response = await bedrock.send(command);
-    const result = JSON.parse(new TextDecoder().decode(response.body));
-    
-    // Anthropic response format on Bedrock
-    const content = result.content[0].text;
-    if (!content) throw new Error('No content returned from AI');
-    
-    // Strip any markdown code blocks if the model included them
-    const jsonStr = content.replace(/```json\n?|\n?```/g, '').trim();
-    return JSON.parse(jsonStr) as RetrofitPlan;
+    const result = JSON.parse(new TextDecoder().decode(response.body)) as { content: Array<{ text: string }> };
+    const text = result.content[0]?.text;
+    if (!text) throw new Error('No content from Bedrock');
+
+    const jsonStr = text.replace(/```json\n?|\n?```/g, '').trim();
+    return JSON.parse(jsonStr) as AnalysisReport;
   } catch (error) {
-    console.error('Failed to analyze repository with AWS Bedrock', error);
+    console.error('[analyzer] Bedrock error:', error);
+    // Return a sensible fallback so the UI still works
     return {
+      detectedStack: {
+        framework: 'Next.js',
+        language: 'typescript',
+        hasAuth: false,
+        authProvider: null,
+        hasPayments: false,
+        paymentsProvider: null,
+        hasDatabase: false,
+        dbProvider: null,
+        hasCI: false,
+      },
       pattern: 'generic',
-      modifications: []
+      injectionOpportunities: [
+        { layer: 'auth', canInject: true, currentState: 'No auth detected', proposed: 'NextAuth.js with InsForge backend', filesToCreate: ['prodify-layer/auth/[...nextauth].ts'], effort: 'low' },
+        { layer: 'payments', canInject: true, currentState: 'No payments detected', proposed: 'Stripe checkout + webhooks', filesToCreate: ['prodify-layer/payments/stripe.ts'], effort: 'low' },
+        { layer: 'database', canInject: true, currentState: 'No database detected', proposed: 'InsForge SQL schema', filesToCreate: ['prodify-layer/db/schema.sql', 'prodify-layer/db/insforge.ts'], effort: 'low' },
+        { layer: 'ci', canInject: true, currentState: 'No CI detected', proposed: 'GitHub Actions — typecheck + test', filesToCreate: ['.github/workflows/ci.yml'], effort: 'low' },
+      ],
+      conflicts: [],
+      summary: 'Analysis could not be completed automatically. All standard injection opportunities are available.',
     };
   }
 }

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -10,7 +10,7 @@ const bedrock = new BedrockRuntimeClient({
   } : undefined,
 });
 
-const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-3-5-sonnet-20241022-v2:0';
 
 export interface InjectionOpportunity {
   layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';

--- a/packages/injector/src/ai/analyzer.ts
+++ b/packages/injector/src/ai/analyzer.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
@@ -10,7 +11,10 @@ const bedrock = new BedrockRuntimeClient({
   } : undefined,
 });
 
-const MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const SONNET_MODEL_ID = process.env.AWS_BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const HAIKU_MODEL_ID = process.env.AWS_BEDROCK_HAIKU_MODEL_ID || 'us.anthropic.claude-3-5-haiku-20241022-v1:0';
+
+// ─── Public interfaces ────────────────────────────────────────────────────────
 
 export interface InjectionOpportunity {
   layer: 'auth' | 'payments' | 'database' | 'ci' | 'env';
@@ -19,10 +23,9 @@ export interface InjectionOpportunity {
   proposed: string;
   filesToCreate: string[];
   effort: 'low' | 'medium' | 'high';
-  // Extended detail fields
-  gaps: string[];           // specific things missing in this layer
-  implementation: string;   // exactly what Prodify will build
-  envVarsNeeded: string[];  // env vars required for this layer
+  gaps: string[];
+  implementation: string;
+  envVarsNeeded: string[];
 }
 
 export interface ConflictWarning {
@@ -30,6 +33,13 @@ export interface ConflictWarning {
   severity: 'warning' | 'blocker';
   resolution: string;
   affectedFiles: string[];
+}
+
+export interface CodeInsight {
+  category: 'auth' | 'payments' | 'database' | 'architecture' | 'security' | 'performance';
+  finding: string;
+  evidence: string;
+  recommendation: string;
 }
 
 export interface AnalysisReport {
@@ -40,27 +50,74 @@ export interface AnalysisReport {
     nodeVersion: string | null;
     hasAuth: boolean;
     authProvider: string | null;
-    authDetails: string | null;       // e.g. "next-auth v4 with GitHub + credentials providers"
+    authDetails: string | null;
     hasPayments: boolean;
     paymentsProvider: string | null;
-    paymentsDetails: string | null;   // e.g. "Stripe SDK found but no webhook handler"
+    paymentsDetails: string | null;
     hasDatabase: boolean;
     dbProvider: string | null;
-    dbDetails: string | null;         // e.g. "Prisma with PostgreSQL, 3 models detected"
+    dbDetails: string | null;
     hasCI: boolean;
     ciDetails: string | null;
-    otherDependencies: string[];      // notable libs: tailwind, shadcn, zod, react-query etc
+    otherDependencies: string[];
   };
   pattern: 'crud' | 'dashboard' | 'landing' | 'ai-app' | 'ecommerce' | 'generic';
-  appDescription: string;             // what the app actually does
+  appDescription: string;
+  apiRoutes: string[];
+  codeInsights: CodeInsight[];
   injectionOpportunities: InjectionOpportunity[];
   conflicts: ConflictWarning[];
   summary: string;
   monetizationReadiness: {
-    score: number;                    // 0-100
-    blockers: string[];               // things that MUST be done before monetizing
-    quickWins: string[];              // things Prodify can inject immediately
+    score: number;
+    blockers: string[];
+    quickWins: string[];
   };
+}
+
+// Phase 1 output — computed for free, used for caching + scoping AI calls
+export interface RepoFingerprint {
+  packageJsonHash: string;
+  framework: string;
+  frameworkVersion: string;
+  language: 'typescript' | 'javascript' | 'unknown';
+  nodeVersion: string | null;
+  deps: {
+    hasNextAuth: boolean;
+    hasClerk: boolean;
+    hasBetterAuth: boolean;
+    hasStripe: boolean;
+    hasLemonSqueezy: boolean;
+    hasPrisma: boolean;
+    hasDrizzle: boolean;
+    hasSupabase: boolean;
+    hasMongoose: boolean;
+    hasTrpc: boolean;
+    hasTailwind: boolean;
+    hasShadcn: boolean;
+    hasZod: boolean;
+    other: string[];
+  };
+  files: {
+    hasMiddleware: boolean;
+    hasPrismaSchema: boolean;
+    hasStripeWebhook: boolean;
+    hasStripeCheckout: boolean;
+    hasAuthConfig: boolean;
+    hasEnvExample: boolean;
+    hasCI: boolean;
+  };
+  partialImpls: string[];
+  fileCount: number;
+  compactTree: string;
+}
+
+// Phase 2 Haiku output — guides which files Phase 3 reads
+interface HaikuInsight {
+  appDescription: string;
+  pattern: 'crud' | 'dashboard' | 'landing' | 'ai-app' | 'ecommerce' | 'generic';
+  userContext: string;
+  focusLayers: Array<'auth' | 'payments' | 'database' | 'ci'>;
 }
 
 // Legacy type kept for backwards compat
@@ -73,97 +130,475 @@ export interface RetrofitPlan {
   }>;
 }
 
-async function readFileSafe(p: string, maxChars = 2000): Promise<string> {
+// ─── File utilities ───────────────────────────────────────────────────────────
+
+async function readFileSafe(p: string, maxChars = 3000): Promise<string> {
   try { return (await fs.readFile(p, 'utf-8')).slice(0, maxChars); } catch { return ''; }
 }
 
-async function buildFileTree(dir: string, maxFiles = 120): Promise<string> {
-  try {
-    const files = await fs.readdir(dir, { recursive: true }) as string[];
-    return files
-      .filter(f =>
-        !f.includes('node_modules') &&
-        !f.includes('.next') &&
-        !f.includes('.git') &&
-        !f.includes('dist') &&
-        !f.includes('.turbo')
-      )
-      .slice(0, maxFiles)
-      .join('\n');
-  } catch { return ''; }
+async function buildFileTree(dir: string): Promise<string> {
+  const IGNORE = new Set(['node_modules', '.next', '.git', 'dist', '.turbo', '.cache', 'coverage', '__pycache__', '.vercel']);
+
+  async function walk(current: string, prefix = '', depth = 0): Promise<string[]> {
+    if (depth > 8) return [];
+    let entries: fs.Dirent[];
+    try { entries = await fs.readdir(current, { withFileTypes: true }); } catch { return []; }
+
+    const filtered = entries
+      .filter(e => !IGNORE.has(e.name) && !e.name.startsWith('.DS_Store'))
+      .sort((a, b) => {
+        if (a.isDirectory() && !b.isDirectory()) return -1;
+        if (!a.isDirectory() && b.isDirectory()) return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+    const lines: string[] = [];
+    for (let i = 0; i < filtered.length; i++) {
+      const entry = filtered[i];
+      const isLast = i === filtered.length - 1;
+      const connector = isLast ? '└── ' : '├── ';
+      const childPrefix = isLast ? '    ' : '│   ';
+      lines.push(`${prefix}${connector}${entry.name}${entry.isDirectory() ? '/' : ''}`);
+      if (entry.isDirectory()) {
+        const children = await walk(path.join(current, entry.name), prefix + childPrefix, depth + 1);
+        lines.push(...children);
+      }
+    }
+    return lines;
+  }
+
+  const lines = await walk(dir);
+  return lines.join('\n');
 }
 
-// Read key source files to give the AI real code context
-async function readKeySourceFiles(dir: string): Promise<string> {
-  const candidates = [
-    // Auth
-    'lib/auth.ts', 'lib/auth.js', 'app/api/auth/[...nextauth]/route.ts',
-    'pages/api/auth/[...nextauth].ts', 'middleware.ts', 'middleware.js',
-    // Payments
-    'lib/stripe.ts', 'lib/stripe.js', 'lib/payments.ts',
-    'app/api/webhooks/stripe/route.ts', 'app/api/checkout/route.ts',
-    'pages/api/webhooks/stripe.ts', 'pages/api/checkout.ts',
-    // Database
-    'lib/db.ts', 'lib/db.js', 'lib/prisma.ts', 'lib/supabase.ts',
-    'prisma/schema.prisma', 'drizzle.config.ts', 'db/schema.ts',
-    // Config
-    'next.config.ts', 'next.config.js', 'next.config.mjs',
-    '.env.example', '.env.local.example',
+async function discoverAndReadApiRoutes(dir: string): Promise<{ paths: string[]; content: string }> {
+  const apiDirs = [
+    path.join(dir, 'app', 'api'),
+    path.join(dir, 'src', 'app', 'api'),
+    path.join(dir, 'pages', 'api'),
+    path.join(dir, 'src', 'pages', 'api'),
   ];
 
-  const results: string[] = [];
-  for (const rel of candidates) {
-    const content = await readFileSafe(path.join(dir, rel), 1500);
-    if (content) {
-      results.push(`\n=== ${rel} ===\n${content}`);
+  const paths: string[] = [];
+  const contentParts: string[] = [];
+
+  for (const apiDir of apiDirs) {
+    if (!await fs.pathExists(apiDir)) continue;
+
+    async function collectRoutes(d: string): Promise<void> {
+      const entries = await fs.readdir(d, { withFileTypes: true }).catch(() => [] as fs.Dirent[]);
+      for (const entry of entries) {
+        const fullPath = path.join(d, entry.name);
+        if (entry.isDirectory()) {
+          await collectRoutes(fullPath);
+        } else if (/\.(ts|js|tsx|jsx)$/.test(entry.name)) {
+          const rel = path.relative(dir, fullPath);
+          paths.push(rel);
+          const content = await readFileSafe(fullPath, 500);
+          if (content) contentParts.push(`\n--- ${rel} ---\n${content}`);
+        }
+      }
     }
+    await collectRoutes(apiDir);
   }
-  return results.join('\n');
+
+  return { paths, content: contentParts.join('\n') };
 }
 
-export async function analyzeRepository(targetDir: string): Promise<AnalysisReport> {
-  const [packageJson, tree, envExample, sourceFiles] = await Promise.all([
-    readFileSafe(path.join(targetDir, 'package.json'), 4000),
-    buildFileTree(targetDir),
-    readFileSafe(path.join(targetDir, '.env.example'), 1500),
-    readKeySourceFiles(targetDir),
+// ─── Phase 1: Programmatic scanner (~50ms, free) ─────────────────────────────
+
+export async function scanRepository(dir: string): Promise<RepoFingerprint> {
+  const pkgContent = await readFileSafe(path.join(dir, 'package.json'), 20000);
+  const packageJsonHash = crypto.createHash('sha256').update(pkgContent || '').digest('hex');
+
+  let pkg: Record<string, unknown> = {};
+  try { pkg = JSON.parse(pkgContent || '{}') as Record<string, unknown>; } catch { /* ignore */ }
+
+  const allDeps = {
+    ...((pkg.dependencies ?? {}) as Record<string, string>),
+    ...((pkg.devDependencies ?? {}) as Record<string, string>),
+  };
+
+  // Framework detection
+  let framework = 'unknown';
+  let frameworkVersion = 'unknown';
+  if (allDeps['next']) { framework = 'Next.js'; frameworkVersion = allDeps['next']; }
+  else if (allDeps['nuxt']) { framework = 'Nuxt'; frameworkVersion = allDeps['nuxt']; }
+  else if (allDeps['@sveltejs/kit']) { framework = 'SvelteKit'; frameworkVersion = allDeps['@sveltejs/kit']; }
+  else if (allDeps['remix']) { framework = 'Remix'; frameworkVersion = allDeps['remix']; }
+  else if (allDeps['react']) { framework = 'React'; frameworkVersion = allDeps['react']; }
+
+  // Language detection
+  const language: 'typescript' | 'javascript' | 'unknown' = await fs.pathExists(path.join(dir, 'tsconfig.json')) ? 'typescript' : 'javascript';
+
+  // Node version
+  let nodeVersion: string | null = null;
+  try { nodeVersion = (await fs.readFile(path.join(dir, '.nvmrc'), 'utf-8')).trim(); } catch { /* ignore */ }
+  const engines = (pkg.engines ?? {}) as Record<string, string>;
+  if (!nodeVersion && engines?.node) nodeVersion = engines.node;
+
+  // Dependency flags
+  const KNOWN_DEPS = new Set(['next', 'react', 'react-dom', 'nuxt', '@sveltejs/kit', 'remix',
+    'typescript', '@types/node', '@types/react', '@types/react-dom', 'eslint',
+    'postcss', 'autoprefixer', 'tailwindcss', 'zod', 'prisma', '@prisma/client',
+    'drizzle-orm', 'next-auth', '@auth/core', '@clerk/nextjs', '@clerk/clerk-sdk-node',
+    'better-auth', 'stripe', '@supabase/supabase-js', 'mongoose', '@trpc/server',
+    '@trpc/client', '@lemonsqueezy/lemonsqueezy-js', 'lemonsqueezy', 'shadcn-ui']);
+
+  const deps = {
+    hasNextAuth: !!(allDeps['next-auth'] || allDeps['@auth/core']),
+    hasClerk: !!(allDeps['@clerk/nextjs'] || allDeps['@clerk/clerk-sdk-node']),
+    hasBetterAuth: !!allDeps['better-auth'],
+    hasStripe: !!allDeps['stripe'],
+    hasLemonSqueezy: !!(allDeps['@lemonsqueezy/lemonsqueezy-js'] || allDeps['lemonsqueezy']),
+    hasPrisma: !!(allDeps['prisma'] || allDeps['@prisma/client']),
+    hasDrizzle: !!allDeps['drizzle-orm'],
+    hasSupabase: !!allDeps['@supabase/supabase-js'],
+    hasMongoose: !!allDeps['mongoose'],
+    hasTrpc: !!(allDeps['@trpc/server'] || allDeps['@trpc/client']),
+    hasTailwind: !!allDeps['tailwindcss'],
+    hasShadcn: !!(allDeps['shadcn-ui'] || await fs.pathExists(path.join(dir, 'components/ui'))),
+    hasZod: !!allDeps['zod'],
+    other: Object.keys(allDeps).filter(d => !KNOWN_DEPS.has(d)).slice(0, 20),
+  };
+
+  // Key file existence checks (run in parallel)
+  const [
+    middlewareTs, middlewareJs,
+    prismaSchema,
+    stripeWebhookApp, stripeWebhookPages,
+    stripeCheckoutApp, stripeCheckoutPages,
+    authLibTs, authLibJs, authRouteApp, authRoutePage,
+    envExample, envLocalExample,
+    ciWorkflows,
+  ] = await Promise.all([
+    fs.pathExists(path.join(dir, 'middleware.ts')),
+    fs.pathExists(path.join(dir, 'middleware.js')),
+    fs.pathExists(path.join(dir, 'prisma/schema.prisma')),
+    fs.pathExists(path.join(dir, 'app/api/webhooks/stripe/route.ts')),
+    fs.pathExists(path.join(dir, 'pages/api/webhooks/stripe.ts')),
+    fs.pathExists(path.join(dir, 'app/api/checkout/route.ts')),
+    fs.pathExists(path.join(dir, 'pages/api/checkout.ts')),
+    fs.pathExists(path.join(dir, 'lib/auth.ts')),
+    fs.pathExists(path.join(dir, 'lib/auth.js')),
+    fs.pathExists(path.join(dir, 'app/api/auth/[...nextauth]/route.ts')),
+    fs.pathExists(path.join(dir, 'pages/api/auth/[...nextauth].ts')),
+    fs.pathExists(path.join(dir, '.env.example')),
+    fs.pathExists(path.join(dir, '.env.local.example')),
+    fs.pathExists(path.join(dir, '.github/workflows')),
   ]);
 
-  const prompt = `You are a senior full-stack engineer and SaaS monetization expert performing a deep technical audit of a GitHub repository. You are preparing a detailed report for a developer who wants to add production-grade auth, payments, and database infrastructure to their existing app.
+  const files = {
+    hasMiddleware: middlewareTs || middlewareJs,
+    hasPrismaSchema: prismaSchema,
+    hasStripeWebhook: stripeWebhookApp || stripeWebhookPages,
+    hasStripeCheckout: stripeCheckoutApp || stripeCheckoutPages,
+    hasAuthConfig: authLibTs || authLibJs || authRouteApp || authRoutePage,
+    hasEnvExample: envExample || envLocalExample,
+    hasCI: ciWorkflows,
+  };
 
-Your analysis must be DEEP, SPECIFIC, and ACTIONABLE — not generic. Reference actual file names, package versions, and code patterns you find. A developer reading this should know EXACTLY what is missing and what needs to be built.
+  // Detect partial implementations
+  const partialImpls: string[] = [];
+  if (deps.hasStripe && !files.hasStripeWebhook) {
+    partialImpls.push('Stripe installed but no webhook handler found');
+  }
+  if (deps.hasStripe && !files.hasStripeCheckout) {
+    partialImpls.push('Stripe installed but no checkout route found');
+  }
+  if (deps.hasNextAuth && !files.hasAuthConfig) {
+    partialImpls.push('next-auth installed but no auth config/route found');
+  }
+  if (deps.hasPrisma && !files.hasPrismaSchema) {
+    partialImpls.push('Prisma installed but no schema.prisma found');
+  }
+  if (deps.hasClerk && files.hasMiddleware) {
+    const mw = await readFileSafe(path.join(dir, middlewareTs ? 'middleware.ts' : 'middleware.js'), 600);
+    if (mw && !mw.toLowerCase().includes('clerk')) {
+      partialImpls.push('Clerk installed but middleware does not import Clerk');
+    }
+  }
 
-=== package.json ===
-${packageJson}
+  // Compact file tree (first 100 lines covers top-level structure well)
+  const fullTree = await buildFileTree(dir);
+  const treeLines = fullTree.split('\n');
+  const fileCount = treeLines.filter(l => !l.trimEnd().endsWith('/')).length;
+  const compactTree = treeLines.slice(0, 100).join('\n');
 
-=== File tree ===
-${tree}
+  return {
+    packageJsonHash,
+    framework,
+    frameworkVersion,
+    language,
+    nodeVersion,
+    deps,
+    files,
+    partialImpls,
+    fileCount,
+    compactTree,
+  };
+}
 
-=== .env.example ===
-${envExample}
+// Cache key — stable across calls for the same repo state
+export function computeCacheKey(cloneUrl: string, headSha: string, packageJsonHash: string): string {
+  return crypto.createHash('sha256')
+    .update(`${cloneUrl}::${headSha}::${packageJsonHash}`)
+    .digest('hex');
+}
 
-=== Key source files ===
-${sourceFiles}
+// ─── Bedrock helpers ──────────────────────────────────────────────────────────
 
----
+async function invokeBedrock(modelId: string, prompt: string, maxTokens: number): Promise<string> {
+  const command = new InvokeModelCommand({
+    modelId,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify({
+      anthropic_version: 'bedrock-2023-05-31',
+      max_tokens: maxTokens,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  const response = await bedrock.send(command);
+  const result = JSON.parse(new TextDecoder().decode(response.body)) as { content: Array<{ text: string }> };
+  const text = result.content[0]?.text;
+  if (!text) throw new Error('Empty response from Bedrock');
+  return text;
+}
 
-DETECTION RULES (only mark as present if you find concrete evidence):
-- hasAuth=true: next-auth/clerk/auth0/supabase-auth/firebase in deps OR auth route files found
-- hasPayments=true: stripe/lemon-squeezy/paddle in deps OR checkout/webhook/billing files found  
-- hasDatabase=true: prisma/drizzle/supabase/mongoose/pg in deps OR schema/migration files found
-- hasCI=true: .github/workflows/ appears in file tree
+function parseJson<T>(text: string): T {
+  const clean = text.replace(/```json\n?|\n?```/g, '').trim();
+  return JSON.parse(clean) as T;
+}
 
-For each injection layer, provide:
-- gaps: specific things that are MISSING (e.g. "No Stripe webhook handler", "No subscription table", "No customer portal route")
-- implementation: detailed description of exactly what will be built (e.g. "Stripe Checkout with price IDs, webhook handler for checkout.session.completed and customer.subscription.*, subscription status stored in DB, customer portal at /api/billing/portal")
-- envVarsNeeded: exact env var names needed (e.g. STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID_MONTHLY)
+// ─── Phase 2: Haiku — App Understanding (~0.002¢) ────────────────────────────
 
-For monetizationReadiness:
-- score: 0-100 based on how close the app is to being able to charge users
-- blockers: specific technical blockers (e.g. "No user identity system — can't associate payments with users", "No database — can't store subscription status")
-- quickWins: things Prodify can inject in one shot (e.g. "Full Stripe checkout + webhook pipeline", "InsForge subscriptions table with RLS")
+async function runHaikuPhase(dir: string, fingerprint: RepoFingerprint): Promise<HaikuInsight> {
+  const readme = await readFileSafe(path.join(dir, 'README.md'), 3000)
+    || await readFileSafe(path.join(dir, 'readme.md'), 3000)
+    || '(no README)';
 
-Return ONLY valid JSON — no markdown, no code fences, no explanation:
+  // Collect a few page file names to give Haiku app structure context
+  const pageDirs = ['app', 'src/app', 'pages', 'src/pages'].map(d => path.join(dir, d));
+  const pageNames: string[] = [];
+  for (const pageDir of pageDirs) {
+    if (!await fs.pathExists(pageDir)) continue;
+    async function collectPageNames(d: string, depth = 0): Promise<void> {
+      if (depth > 4 || pageNames.length > 30) return;
+      const entries = await fs.readdir(d, { withFileTypes: true }).catch(() => [] as fs.Dirent[]);
+      for (const e of entries) {
+        if (['node_modules', '.next', 'api'].includes(e.name)) continue;
+        if (e.isDirectory()) await collectPageNames(path.join(d, e.name), depth + 1);
+        else if (/^(page|layout)\.(tsx|jsx|ts|js)$/.test(e.name)) {
+          pageNames.push(path.relative(dir, path.join(d, e.name)));
+        }
+      }
+    }
+    await collectPageNames(pageDir);
+    break; // only scan the first found page dir
+  }
+
+  const fingerprintSummary = JSON.stringify({
+    framework: fingerprint.framework,
+    language: fingerprint.language,
+    deps: fingerprint.deps,
+    files: fingerprint.files,
+    partialImpls: fingerprint.partialImpls,
+    fileCount: fingerprint.fileCount,
+  }, null, 2);
+
+  const prompt = `You are a fast technical classifier. Identify what this app is and which injection layers matter most.
+
+=== README ===
+${readme}
+
+=== Page files ===
+${pageNames.join('\n') || '(none found)'}
+
+=== Detected dependencies & files ===
+${fingerprintSummary}
+
+Return ONLY valid JSON with no explanation:
+{
+  "appDescription": "2-3 sentences describing what the app does based on README and page structure",
+  "pattern": "crud" | "dashboard" | "landing" | "ai-app" | "ecommerce" | "generic",
+  "userContext": "1 sentence: who uses it and why",
+  "focusLayers": ["auth", "payments", "database", "ci"]
+}
+
+For focusLayers: include all layers that need DEEP investigation. Include "auth" if hasNextAuth/hasClerk/hasBetterAuth is false OR partial. Include "payments" if hasStripe is false OR partial webhook. Include "database" if hasPrisma/hasDrizzle/hasSupabase is false. Include "ci" if hasCI is false. Always include at least 2 layers.`;
+
+  try {
+    const text = await invokeBedrock(HAIKU_MODEL_ID, prompt, 400);
+    return parseJson<HaikuInsight>(text);
+  } catch {
+    // Fallback: infer from fingerprint without Haiku
+    const focusLayers: HaikuInsight['focusLayers'] = [];
+    const { deps, files } = fingerprint;
+    if (!deps.hasNextAuth && !deps.hasClerk && !deps.hasBetterAuth) focusLayers.push('auth');
+    if (!deps.hasStripe && !deps.hasLemonSqueezy) focusLayers.push('payments');
+    if (!deps.hasPrisma && !deps.hasDrizzle && !deps.hasSupabase && !deps.hasMongoose) focusLayers.push('database');
+    if (!files.hasCI) focusLayers.push('ci');
+    return {
+      appDescription: 'App description unavailable — proceeding with full analysis.',
+      pattern: 'generic',
+      userContext: 'Unknown',
+      focusLayers: focusLayers.length ? focusLayers : ['auth', 'payments', 'database', 'ci'],
+    };
+  }
+}
+
+// ─── Phase 3: Sonnet — Plan + Safety Check (~2–3¢) ───────────────────────────
+
+async function buildTargetedContext(
+  dir: string,
+  fingerprint: RepoFingerprint,
+  focusLayers: HaikuInsight['focusLayers'],
+): Promise<string> {
+  // Always-include files (small, high signal)
+  const always: Array<{ path: string; maxChars: number }> = [
+    { path: 'package.json', maxChars: 4000 },
+    { path: 'apps/web/package.json', maxChars: 3000 },
+    { path: 'next.config.ts', maxChars: 2000 },
+    { path: 'next.config.js', maxChars: 2000 },
+    { path: 'next.config.mjs', maxChars: 2000 },
+    { path: 'tsconfig.json', maxChars: 1500 },
+    { path: 'app/layout.tsx', maxChars: 2000 },
+    { path: 'src/app/layout.tsx', maxChars: 2000 },
+    { path: 'app/page.tsx', maxChars: 1500 },
+    { path: 'src/app/page.tsx', maxChars: 1500 },
+  ];
+
+  // Layer-specific files — only loaded when that layer is in focusLayers
+  const layerFiles: Record<string, Array<{ path: string; maxChars: number }>> = {
+    auth: [
+      { path: 'lib/auth.ts', maxChars: 4000 },
+      { path: 'lib/auth.js', maxChars: 4000 },
+      { path: 'src/lib/auth.ts', maxChars: 4000 },
+      { path: 'app/api/auth/[...nextauth]/route.ts', maxChars: 4000 },
+      { path: 'pages/api/auth/[...nextauth].ts', maxChars: 4000 },
+      { path: 'middleware.ts', maxChars: 3000 },
+      { path: 'middleware.js', maxChars: 3000 },
+    ],
+    payments: [
+      { path: 'lib/stripe.ts', maxChars: 4000 },
+      { path: 'lib/stripe.js', maxChars: 4000 },
+      { path: 'lib/payments.ts', maxChars: 4000 },
+      { path: 'app/api/webhooks/stripe/route.ts', maxChars: 4000 },
+      { path: 'app/api/checkout/route.ts', maxChars: 3000 },
+      { path: 'pages/api/webhooks/stripe.ts', maxChars: 4000 },
+      { path: 'pages/api/checkout.ts', maxChars: 3000 },
+    ],
+    database: [
+      { path: 'prisma/schema.prisma', maxChars: 5000 },
+      { path: 'db/schema.ts', maxChars: 5000 },
+      { path: 'src/db/schema.ts', maxChars: 5000 },
+      { path: 'drizzle.config.ts', maxChars: 2000 },
+      { path: 'lib/db.ts', maxChars: 3000 },
+      { path: 'lib/db.js', maxChars: 3000 },
+      { path: 'lib/prisma.ts', maxChars: 2000 },
+      { path: 'lib/supabase.ts', maxChars: 3000 },
+      { path: 'src/lib/db.ts', maxChars: 3000 },
+    ],
+    ci: [
+      { path: '.github/workflows/ci.yml', maxChars: 2000 },
+      { path: '.github/workflows/main.yml', maxChars: 2000 },
+      { path: '.env.example', maxChars: 3000 },
+      { path: '.env.local.example', maxChars: 3000 },
+    ],
+  };
+
+  const targets = [...always];
+  for (const layer of focusLayers) {
+    if (layerFiles[layer]) targets.push(...layerFiles[layer]);
+  }
+
+  // De-dupe paths
+  const seen = new Set<string>();
+  const unique = targets.filter(t => {
+    if (seen.has(t.path)) return false;
+    seen.add(t.path);
+    return true;
+  });
+
+  const parts: string[] = [];
+  for (const t of unique) {
+    const content = await readFileSafe(path.join(dir, t.path), t.maxChars);
+    if (content) parts.push(`\n=== ${t.path} ===\n${content}`);
+  }
+  return parts.join('\n');
+}
+
+// ─── Phase 3: Sonnet analysis ─────────────────────────────────────────────────
+
+async function runSonnetPhase(
+  dir: string,
+  fingerprint: RepoFingerprint,
+  haiku: HaikuInsight,
+): Promise<AnalysisReport> {
+  const [sourceFiles, apiRoutes] = await Promise.all([
+    buildTargetedContext(dir, fingerprint, haiku.focusLayers),
+    discoverAndReadApiRoutes(dir),
+  ]);
+
+  const fingerprintJson = JSON.stringify({
+    framework: fingerprint.framework,
+    frameworkVersion: fingerprint.frameworkVersion,
+    language: fingerprint.language,
+    nodeVersion: fingerprint.nodeVersion,
+    deps: fingerprint.deps,
+    files: fingerprint.files,
+    partialImpls: fingerprint.partialImpls,
+    fileCount: fingerprint.fileCount,
+  }, null, 2);
+
+  const prompt = `You are a senior full-stack engineer and SaaS monetization expert auditing a GitHub repository. Every claim must be grounded in the actual code provided below.
+
+=== PHASE 1 FINGERPRINT (pre-computed, trust this) ===
+${fingerprintJson}
+
+=== PHASE 2 APP CONTEXT ===
+appDescription: ${haiku.appDescription}
+pattern: ${haiku.pattern}
+userContext: ${haiku.userContext}
+focusLayers: ${haiku.focusLayers.join(', ')}
+
+=== FILE TREE (compact) ===
+${fingerprint.compactTree}
+
+=== TARGETED SOURCE FILES (auth/payments/db/ci for focus layers only) ===
+${sourceFiles || '(no source files found)'}
+
+=== API ROUTES ===
+${apiRoutes.content || '(no API routes found)'}
+
+===========================================================
+INSTRUCTIONS
+===========================================================
+
+The detectedStack values for hasAuth/hasPayments/hasDatabase/hasCI can be inferred directly from the fingerprint — use it. Focus your AI reasoning on:
+1. Specific code-level insights (bugs, gaps, partial impls) found in the source files above
+2. Detailed injection plans for the focusLayers: ${haiku.focusLayers.join(', ')}
+3. Conflict detection between existing code and proposed injections
+
+DETECTION RULES — only mark as present with concrete fingerprint/code evidence:
+- hasAuth: fingerprint.deps.hasNextAuth/hasClerk/hasBetterAuth, OR auth route file with actual handler code
+- hasPayments: fingerprint.deps.hasStripe/hasLemonSqueezy, OR checkout/webhook route with actual handler
+- hasDatabase: fingerprint.deps.hasPrisma/hasDrizzle/hasSupabase/hasMongoose, OR schema file with models
+- hasCI: fingerprint.files.hasCI
+
+For codeInsights, find REAL specific things:
+- "Found useSession() called in dashboard/page.tsx but no SessionProvider in layout.tsx"
+- "prisma/schema.prisma has User and Post models but no Subscription model"
+- "Stripe SDK installed but app/api/webhooks/stripe/route.ts is missing"
+
+For injectionOpportunities, reference actual files found. Include ALL layers (auth/payments/database/ci/env), not just focusLayers.
+
+For monetizationReadiness score: 0=nothing, 30=DB only, 50=DB+auth, 70=DB+auth+partial payments, 90+=fully wired.
+
+For apiRoutes: ${JSON.stringify(apiRoutes.paths)}
+
+Return ONLY valid JSON — no markdown, no code fences:
 
 {
   "detectedStack": {
@@ -173,141 +608,126 @@ Return ONLY valid JSON — no markdown, no code fences, no explanation:
     "nodeVersion": string | null,
     "hasAuth": boolean,
     "authProvider": string | null,
-    "authDetails": string | null,
+    "authDetails": "specific: e.g. next-auth v4.24.5 with GitHub OAuth, sessions in JWT",
     "hasPayments": boolean,
     "paymentsProvider": string | null,
-    "paymentsDetails": string | null,
+    "paymentsDetails": "specific: e.g. stripe@14.x installed but no webhook handler",
     "hasDatabase": boolean,
     "dbProvider": string | null,
-    "dbDetails": string | null,
+    "dbDetails": "specific: e.g. Prisma v5.x with PostgreSQL, User+Post models, no Subscription table",
     "hasCI": boolean,
     "ciDetails": string | null,
-    "otherDependencies": ["array of notable libs"]
+    "otherDependencies": ["notable ones: tailwind, shadcn, zod, react-query, trpc, etc."]
   },
   "pattern": "crud" | "dashboard" | "landing" | "ai-app" | "ecommerce" | "generic",
-  "appDescription": "2-3 sentences describing what this app actually does based on the code",
+  "appDescription": "3-4 sentences based on README and pages",
+  "apiRoutes": ["every api route file path discovered"],
+  "codeInsights": [
+    {
+      "category": "auth" | "payments" | "database" | "architecture" | "security" | "performance",
+      "finding": "short title",
+      "evidence": "exact file/package proving this",
+      "recommendation": "specific fix or what Prodify does"
+    }
+  ],
   "injectionOpportunities": [
     {
       "layer": "auth" | "payments" | "database" | "ci" | "env",
       "canInject": boolean,
-      "currentState": "specific description of what exists, referencing actual files/packages found",
-      "proposed": "specific description of what will be injected",
-      "filesToCreate": ["exact/file/paths/that/will/be/created.ts"],
+      "currentState": "reference actual files/packages found",
+      "proposed": "specific routes, packages, schema tables",
+      "filesToCreate": ["exact/relative/paths.ts"],
       "effort": "low" | "medium" | "high",
-      "gaps": ["specific gap 1", "specific gap 2"],
-      "implementation": "detailed paragraph describing exactly what will be built and how it integrates with the existing code",
-      "envVarsNeeded": ["EXACT_ENV_VAR_NAME_1", "EXACT_ENV_VAR_NAME_2"]
+      "gaps": ["specific gap referencing missing code"],
+      "implementation": "detailed paragraph: exact API routes, functions, DB schema fields, webhook events, integration points",
+      "envVarsNeeded": ["EXACT_VAR_NAME"]
     }
   ],
   "conflicts": [
     {
-      "description": "specific conflict referencing actual files/packages",
+      "description": "specific conflict referencing actual files",
       "severity": "warning" | "blocker",
-      "resolution": "concrete step-by-step resolution",
-      "affectedFiles": ["file/that/conflicts.ts"]
+      "resolution": "concrete steps",
+      "affectedFiles": ["actual/file/paths.ts"]
     }
   ],
-  "summary": "3-4 sentences: what the app does, exact infrastructure state, what is missing, monetization gap",
+  "summary": "4-5 sentences: what the app does, exact infrastructure state, what is missing, why monetization isn't possible yet, what Prodify fixes",
   "monetizationReadiness": {
-    "score": 0-100,
-    "blockers": ["specific blocker 1", "specific blocker 2"],
-    "quickWins": ["specific quick win 1", "specific quick win 2"]
+    "score": 0,
+    "blockers": ["specific technical blocker grounded in code"],
+    "quickWins": ["specific Prodify injection that unblocks a blocker"]
   }
 }`;
 
-  const payload = {
-    anthropic_version: 'bedrock-2023-05-31',
-    max_tokens: 4000,
-    messages: [{ role: 'user', content: prompt }],
+  const text = await invokeBedrock(SONNET_MODEL_ID, prompt, 8000);
+  return parseJson<AnalysisReport>(text);
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+// Phase 2 + 3 combined — call this after a cache miss
+export async function analyzeWithAI(dir: string, fingerprint: RepoFingerprint): Promise<AnalysisReport> {
+  const haiku = await runHaikuPhase(dir, fingerprint);
+  return runSonnetPhase(dir, fingerprint, haiku);
+}
+
+// Convenience wrapper: scan + analyze in one call
+export async function analyzeRepository(dir: string): Promise<AnalysisReport> {
+  const fingerprint = await scanRepository(dir);
+  return analyzeWithAI(dir, fingerprint);
+}
+
+// ─── Fallback report (used on unrecoverable error) ────────────────────────────
+
+export function buildFallbackReport(): AnalysisReport {
+  return {
+    detectedStack: {
+      framework: 'Next.js', frameworkVersion: 'unknown', language: 'typescript',
+      nodeVersion: null, hasAuth: false, authProvider: null, authDetails: null,
+      hasPayments: false, paymentsProvider: null, paymentsDetails: null,
+      hasDatabase: false, dbProvider: null, dbDetails: null,
+      hasCI: false, ciDetails: null, otherDependencies: [],
+    },
+    pattern: 'generic',
+    appDescription: 'Analysis could not be completed. Please try again.',
+    apiRoutes: [],
+    codeInsights: [],
+    injectionOpportunities: [
+      {
+        layer: 'auth', canInject: true, currentState: 'Not found in codebase',
+        proposed: 'NextAuth.js with InsForge backend',
+        filesToCreate: ['prodify-layer/auth/[...nextauth].ts'], effort: 'low',
+        gaps: ['No authentication system detected'],
+        implementation: 'NextAuth.js with credentials + GitHub OAuth, session management via InsForge',
+        envVarsNeeded: ['NEXTAUTH_SECRET', 'NEXTAUTH_URL'],
+      },
+      {
+        layer: 'payments', canInject: true, currentState: 'Not found in codebase',
+        proposed: 'Stripe Checkout + webhooks + customer portal',
+        filesToCreate: ['prodify-layer/payments/stripe.ts', 'prodify-layer/app/api/checkout/route.ts', 'prodify-layer/app/api/webhooks/stripe/route.ts'],
+        effort: 'medium', gaps: ['No Stripe integration', 'No webhook handler'],
+        implementation: 'Full Stripe Checkout with subscription management and customer portal',
+        envVarsNeeded: ['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'STRIPE_PRICE_ID'],
+      },
+      {
+        layer: 'database', canInject: true, currentState: 'Not found in codebase',
+        proposed: 'InsForge SQL schema with users, subscriptions tables',
+        filesToCreate: ['prodify-layer/db/schema.sql', 'prodify-layer/db/insforge.ts'],
+        effort: 'low', gaps: ['No database schema'],
+        implementation: 'InsForge PostgreSQL schema with users, subscriptions, and webhook_events tables',
+        envVarsNeeded: ['INSFORGE_URL', 'INSFORGE_ANON_KEY'],
+      },
+      {
+        layer: 'ci', canInject: true, currentState: 'Not found in codebase',
+        proposed: 'GitHub Actions — typecheck + test on push/PR',
+        filesToCreate: ['.github/workflows/ci.yml'], effort: 'low',
+        gaps: ['No automated testing pipeline'],
+        implementation: 'GitHub Actions workflow running tsc --noEmit and npm test on every push and PR',
+        envVarsNeeded: [],
+      },
+    ],
+    conflicts: [],
+    summary: 'Analysis could not be completed automatically. All standard injection opportunities are available.',
+    monetizationReadiness: { score: 0, blockers: ['Analysis failed — please retry'], quickWins: [] },
   };
-
-  try {
-    const command = new InvokeModelCommand({
-      modelId: MODEL_ID,
-      contentType: 'application/json',
-      accept: 'application/json',
-      body: JSON.stringify(payload),
-    });
-
-    const response = await bedrock.send(command);
-    const result = JSON.parse(new TextDecoder().decode(response.body)) as { content: Array<{ text: string }> };
-    const text = result.content[0]?.text;
-    if (!text) throw new Error('No content from Bedrock');
-
-    const jsonStr = text.replace(/```json\n?|\n?```/g, '').trim();
-    return JSON.parse(jsonStr) as AnalysisReport;
-  } catch (error) {
-    console.error('[analyzer] Bedrock error:', error);
-    return {
-      detectedStack: {
-        framework: 'Next.js',
-        frameworkVersion: 'unknown',
-        language: 'typescript',
-        nodeVersion: null,
-        hasAuth: false,
-        authProvider: null,
-        authDetails: null,
-        hasPayments: false,
-        paymentsProvider: null,
-        paymentsDetails: null,
-        hasDatabase: false,
-        dbProvider: null,
-        dbDetails: null,
-        hasCI: false,
-        ciDetails: null,
-        otherDependencies: [],
-      },
-      pattern: 'generic',
-      appDescription: 'Analysis could not be completed. Please try again.',
-      injectionOpportunities: [
-        {
-          layer: 'auth', canInject: true,
-          currentState: 'No auth detected',
-          proposed: 'NextAuth.js with InsForge backend',
-          filesToCreate: ['prodify-layer/auth/[...nextauth].ts'],
-          effort: 'low',
-          gaps: ['No authentication system'],
-          implementation: 'NextAuth.js with credentials + GitHub OAuth, session management via InsForge',
-          envVarsNeeded: ['NEXTAUTH_SECRET', 'NEXTAUTH_URL'],
-        },
-        {
-          layer: 'payments', canInject: true,
-          currentState: 'No payments detected',
-          proposed: 'Stripe Checkout + webhooks + customer portal',
-          filesToCreate: ['prodify-layer/payments/stripe.ts', 'prodify-layer/app/api/checkout/route.ts', 'prodify-layer/app/api/webhooks/stripe/route.ts'],
-          effort: 'medium',
-          gaps: ['No Stripe integration', 'No subscription management', 'No webhook handler'],
-          implementation: 'Full Stripe Checkout flow with subscription management, webhook handler for lifecycle events, customer portal',
-          envVarsNeeded: ['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'STRIPE_PRICE_ID'],
-        },
-        {
-          layer: 'database', canInject: true,
-          currentState: 'No database detected',
-          proposed: 'InsForge SQL schema with users, subscriptions tables',
-          filesToCreate: ['prodify-layer/db/schema.sql', 'prodify-layer/db/insforge.ts'],
-          effort: 'low',
-          gaps: ['No database schema', 'No user table', 'No subscription tracking'],
-          implementation: 'InsForge PostgreSQL schema with users, subscriptions, and webhook_events tables',
-          envVarsNeeded: ['INSFORGE_URL', 'INSFORGE_ANON_KEY'],
-        },
-        {
-          layer: 'ci', canInject: true,
-          currentState: 'No CI detected',
-          proposed: 'GitHub Actions — typecheck + test on push/PR',
-          filesToCreate: ['.github/workflows/ci.yml'],
-          effort: 'low',
-          gaps: ['No automated testing pipeline'],
-          implementation: 'GitHub Actions workflow running tsc --noEmit and npm test on every push and PR',
-          envVarsNeeded: [],
-        },
-      ],
-      conflicts: [],
-      summary: 'Analysis could not be completed automatically. All standard injection opportunities are available.',
-      monetizationReadiness: {
-        score: 0,
-        blockers: ['Analysis failed — please retry'],
-        quickWins: [],
-      },
-    };
-  }
 }

--- a/packages/injector/src/types.ts
+++ b/packages/injector/src/types.ts
@@ -15,6 +15,7 @@ export interface ProdifyAnswers {
   pricingModel: PricingModel;
   userType: UserType;
   stack: StackType;
+  autoDeploy?: boolean;
 }
 
 // ─── Runtime Config ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Phase 1**: GitHub OAuth repo import — connect GitHub, pick repos, import by URL
- **Phases 2–4**: AI analysis, project workspace, injection pipeline
- **Phase 6**: Activity feed on dashboard + GitHub connection tab in settings
- **Phase 7**: API keys (generate/revoke) + real delete account with typed confirmation
- **Analyzer overhaul**: 3-phase cost-optimized scanner (~70% token reduction)
  - Phase 1: free programmatic scan (package.json, file-existence, partial-impl detection, SHA-256 fingerprint)
  - Phase 2: Haiku (~0.002¢) — app understanding, focusLayers selection
  - Phase 3: Sonnet (~2–3¢) — targeted context for detected layers only
  - Cache layer: repeat analyses of the same commit are free (SHA-256 keyed by cloneUrl + headSha + pkgHash)

## Test plan

- [ ] GitHub OAuth connect flow works (connect → pick repo → import)
- [ ] Analysis runs and shows monetization score, code insights, injection opportunities
- [ ] Re-analyzing same repo commit returns instantly (cache hit)
- [ ] Activity feed updates after analyze/inject actions
- [ ] API key generate/revoke works in settings
- [ ] Delete account with typed confirmation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)